### PR TITLE
Don't hardcode values in prelogin secret and don't generate it if it …

### DIFF
--- a/.changeset/lemon-impalas-turn.md
+++ b/.changeset/lemon-impalas-turn.md
@@ -1,0 +1,5 @@
+---
+"comet-site-v8": minor
+---
+
+BREAKING: Don't hardcode values in prelogin secret and don't generate it if it would be empty. They have to be filled with Values.prelogin.secrets

--- a/charts/comet-site-v8/templates/prelogin-secret.yaml
+++ b/charts/comet-site-v8/templates/prelogin-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prelogin.enabled -}}
+{{- if and (.Values.prelogin.enabled) (.Values.prelogin.secrets) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +7,7 @@ metadata:
     {{- include "comet-site.prelogin.labels" . | nindent 8 }}
 type: Opaque
 stringData:
-  IDP_CLIENT_SECRET: {{ .Values.prelogin.idp.clientSecret | quote }}
-  NEXTAUTH_SECRET: {{ .Values.prelogin.idp.clientSecret | quote }}
+  {{- range $key, $val := .Values.prelogin.secrets }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-site-v8/values.yaml
+++ b/charts/comet-site-v8/values.yaml
@@ -75,6 +75,7 @@ prelogin:
   requiredUserDomain: ""
   autoMountServiceAccountToken: true
   additionalLabels: {}
+  secrets: {}
 
   image:
     repository: "" # will be overwritten by CI


### PR DESCRIPTION
…would be empty. They have to be filled with Values.prelogin.secrets