### PR TITLE
Revert to executing npm-command for migrations

### DIFF
--- a/.changeset/clean-buckets-fetch.md
+++ b/.changeset/clean-buckets-fetch.md
@@ -1,0 +1,6 @@
+---
+"comet-api-v10": minor
+"comet-api-v9": minor
+---
+
+Revert to executing npm-command for migrations but make them overrideable

--- a/charts/comet-api-v10/templates/deployment.yaml
+++ b/charts/comet-api-v10/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["bash", "-c", "node dist/console.js migrate"]
+          command: ["bash", "-c", {{ .Values.migrateCommand }}]
           envFrom:
             {{- if .Values.env }}
             - configMapRef:

--- a/charts/comet-api-v10/values.yaml
+++ b/charts/comet-api-v10/values.yaml
@@ -83,6 +83,8 @@ readinessProbe:
     port: http
   initialDelaySeconds: 5
 
+migrateCommand: "npm run console:prod migrate"
+
 cronJobs:
   blck-indx-mgrt-blks:
     enabled: true

--- a/charts/comet-api-v9/templates/deployment.yaml
+++ b/charts/comet-api-v9/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["bash", "-c", "node dist/console.js migrate"]
+          command: ["bash", "-c", {{ .Values.migrateCommand }}]
           envFrom:
             {{- if .Values.env }}
             - configMapRef:

--- a/charts/comet-api-v9/values.yaml
+++ b/charts/comet-api-v9/values.yaml
@@ -80,6 +80,8 @@ readinessProbe:
     port: http
   initialDelaySeconds: 5
 
+migrateCommand: "npm run console:prod migrate"
+
 cronJobs:
   build-checker:
     enabled: true


### PR DESCRIPTION
Reasons:
- we don't want to hardcode the path `dist/console.js`
- we would need to change all npm-calls (e.g. for Cron-Jobs)

Since npm is available in most environments we rather make it configurable and keep the old commands.