### PR TITLE
Add option to mount .next folder as emptyDir

### DIFF
--- a/.changeset/afraid-mayflies-admire.md
+++ b/.changeset/afraid-mayflies-admire.md
@@ -1,0 +1,5 @@
+---
+"comet-site-v1": minor
+---
+
+Add option to mount .next folder as emptyDir

--- a/charts/comet-site-v1/templates/deployment.yaml
+++ b/charts/comet-site-v1/templates/deployment.yaml
@@ -79,8 +79,10 @@ spec:
             - mountPath: /tmp
               name: tmp
           {{- end }}
+          {{- if .Values.mountEmptyDirAsNextFolder }}
             - mountPath: /opt/app-root/src/.next
               name: document-root
+          {{- end }}
           resources:
             {{- toYaml .Values.initContainer.resources | nindent 12 }}
       {{- end }}
@@ -122,8 +124,10 @@ spec:
             - mountPath: /mnt/generated-sites/
               name: generated-sites
           {{- end }}
+          {{- if .Values.mountEmptyDirAsNextFolder }}
             - mountPath: /opt/app-root/src/.next
               name: document-root
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000
@@ -170,5 +174,7 @@ spec:
         - name: tmp
           emptyDir: {}
     {{- end }}
+    {{- if .Values.mountEmptyDirAsNextFolder }}
         - name: document-root
           emptyDir: {}
+    {{- end }}

--- a/charts/comet-site-v1/values.yaml
+++ b/charts/comet-site-v1/values.yaml
@@ -140,3 +140,5 @@ pvc:
 
 persistence:
   existingClaim: ""
+
+mountEmptyDirAsNextFolder: false


### PR DESCRIPTION
This is needed to support Comet 6 with SSG, Comet 6 without build (eg newsletter webs) and Comet 7 with SSR