### PR TITLE
Rename comet-api RoleBinding to avoid conflict with existing RoleBinding

### DIFF
--- a/.changeset/thick-ways-appear.md
+++ b/.changeset/thick-ways-appear.md
@@ -1,0 +1,5 @@
+---
+"comet-api-v1": patch
+---
+
+Rename comet-api RoleBinding to avoid conflict with existing RoleBinding due to roleRef changes

--- a/charts/comet-api-v1/templates/service-account.yaml
+++ b/charts/comet-api-v1/templates/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "comet-api.serviceAccountName" . }}
+  name: {{ include "comet-api.serviceAccountName" . }}-restricted
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
The existing `RoleBinding` cannot be adjusted because the `roleRef` is immutable. Therefore, a new `RoleBinding` must be created with a different name.

`roleRef` was changed here: https://github.com/vivid-planet/comet-charts/pull/114/files