### PR TITLE
Add app label to API and Admin charts

### DIFF
--- a/.changeset/slow-meals-lick.md
+++ b/.changeset/slow-meals-lick.md
@@ -1,0 +1,6 @@
+---
+"comet-admin-v1": minor
+"comet-api-v1": minor
+---
+
+Add app label to api and admin charts to match the existing label configuration

--- a/charts/comet-admin-v1/templates/_helpers.tpl
+++ b/charts/comet-admin-v1/templates/_helpers.tpl
@@ -46,6 +46,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "comet-admin.selectorLabels" -}}
+app: {{ include "comet-admin.fullname" . }}
 app.kubernetes.io/name: {{ include "comet-admin.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/comet-api-v1/templates/_helpers.tpl
+++ b/charts/comet-api-v1/templates/_helpers.tpl
@@ -46,6 +46,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "comet-api.selectorLabels" -}}
+app: {{ include "comet-api.fullname" . }}
 app.kubernetes.io/name: {{ include "comet-api.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
Add app label to `api` and `admin` templates to match the existing label in the `site` chart.
Site label: https://github.com/vivid-planet/comet-charts/blob/5edcbdf6f3eb41aa2caba494d66b122d84c703fc/charts/comet-site-v1/templates/_helpers.tpl#L49