### PR TITLE
Add openshift-monitoring helm chart

### DIFF
--- a/.changeset/twenty-books-bake.md
+++ b/.changeset/twenty-books-bake.md
@@ -1,0 +1,7 @@
+---
+"openshift-monitoring": major
+---
+
+Add `openshift-monitoring` chart
+
+Provides a centralized configuration for monitoring services and configurations.

--- a/charts/openshift-monitoring/.helmignore
+++ b/charts/openshift-monitoring/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/openshift-monitoring/Chart.yaml
+++ b/charts/openshift-monitoring/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: openshift-monitoring
+description: A Helm chart for OpenShift Monitoring components
+type: application
+
+maintainers:
+  - name: Daniel Karnutsch
+    email: daniel.karnutsch@vivid-planet.com
+  - name: Georg Schreglmann
+    email: georg.schreglmann@vivid-planet.com
+  - name: Franz Unger
+    email: franz.unger@vivid-planet.com
+  - name: Alexander Kaufmann
+    email: alexander.kaufmann@vivid-planet.com
+  - name: Philipp Pregernigg
+    email: philipp.pregernigg@vivid-planet.com
+
+version: 0.0.0

--- a/charts/openshift-monitoring/package.json
+++ b/charts/openshift-monitoring/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "openshift-monitoring",
+    "private": true,
+    "version": "0.0.0"
+}

--- a/charts/openshift-monitoring/templates/_helpers.tpl
+++ b/charts/openshift-monitoring/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openshift-monitoring.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openshift-monitoring.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openshift-monitoring.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openshift-monitoring.labels" -}}
+helm.sh/chart: {{ include "openshift-monitoring.chart" . }}
+{{ include "openshift-monitoring.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openshift-monitoring.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openshift-monitoring.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openshift-monitoring.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openshift-monitoring.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/openshift-monitoring/templates/role-binding.yaml
+++ b/charts/openshift-monitoring/templates/role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-monitoring-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-monitoring-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-monitoring-service-account

--- a/charts/openshift-monitoring/templates/role.yaml
+++ b/charts/openshift-monitoring/templates/role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-monitoring-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]

--- a/charts/openshift-monitoring/templates/service-account.yaml
+++ b/charts/openshift-monitoring/templates/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-monitoring-service-account
+secrets:
+  - name: {{ .Release.Name }}-monitoring-service-account-token

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,22 +18,25 @@
             }
         },
         "charts/comet-admin-v1": {
-            "version": "1.0.0"
+            "version": "1.4.0"
         },
         "charts/comet-api-v1": {
-            "version": "1.1.0"
+            "version": "1.6.1"
         },
         "charts/comet-ingress-v1": {
-            "version": "1.0.0"
-        },
-        "charts/comet-site-preview-v1": {
             "version": "1.0.1"
         },
-        "charts/comet-site-v1": {
+        "charts/comet-site-preview-v1": {
             "version": "1.1.0"
+        },
+        "charts/comet-site-v1": {
+            "version": "1.4.0"
         },
         "charts/imgproxy": {
             "version": "0.10.2"
+        },
+        "charts/openshift-monitoring": {
+            "version": "0.0.0"
         },
         "node_modules/@babel/runtime": {
             "version": "7.26.0",
@@ -1455,6 +1458,10 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/openshift-monitoring": {
+            "resolved": "charts/openshift-monitoring",
+            "link": true
         },
         "node_modules/os-tmpdir": {
             "version": "1.0.2",


### PR DESCRIPTION
feat: centralize configuration for monitoring services

- Provides a centralized configuration for monitoring services and configurations.
- Current services are needed for OpenShift authentication.
- Configuration for Grafana-Alloy will follow.