### PR TITLE
Add configuration to expose metrics port for services

### DIFF
--- a/.changeset/young-actors-listen.md
+++ b/.changeset/young-actors-listen.md
@@ -1,0 +1,7 @@
+---
+"comet-admin-v1": minor
+"comet-site-v1": minor
+"comet-api-v1": minor
+---
+
+Add configuration to expose metrics port for services

--- a/charts/comet-admin-v1/templates/service.yaml
+++ b/charts/comet-admin-v1/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.containerPorts.http }}
+      targetPort: metrics
+    {{- end }}
   selector:
     {{- include "comet-admin.selectorLabels" . | nindent 4 }}

--- a/charts/comet-api-v1/templates/service.yaml
+++ b/charts/comet-api-v1/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.containerPorts.http }}
+      targetPort: metrics
+    {{- end }}
   selector:
     {{- include "comet-api.selectorLabels" . | nindent 4 }}

--- a/charts/comet-site-v1/templates/service.yaml
+++ b/charts/comet-site-v1/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.containerPorts.http }}
+      targetPort: metrics
+    {{- end }}
   selector:
     {{- include "comet-site.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Extends: https://github.com/vivid-planet/comet-charts/pull/126  

- Expose ports on Services to enable metric scraping using the `ServiceMonitor` resource.  
- The service will use the same port (`containerPorts.http`) as the Pod.  
