### PR TITLE
Add timeZone configuration to cronjobs definition

### DIFF
--- a/.changeset/itchy-pets-search.md
+++ b/.changeset/itchy-pets-search.md
@@ -1,0 +1,5 @@
+---
+"comet-api-v1": minor
+---
+
+Add timeZone configuration to cronjobs definition

--- a/charts/comet-api-v1/templates/cron-jobs.yaml
+++ b/charts/comet-api-v1/templates/cron-jobs.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- end }}
 spec:
   schedule: {{ $job.schedule | quote }}
+  timeZone: {{ $job.timeZone | default "Europe/Vienna" }}
   successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit | default 2 }}
   failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit | default 2 }}
   concurrencyPolicy: {{ $job.concurrencyPolicy | default "Forbid" }}


### PR DESCRIPTION
Why:
Cronjobs interprets schedules relative to its time zone. Sometimes its necessary to overwrite this time zone for example if the server is not in the same time zone as the deployed cronjob. With this change its now possible to overwrite the time zone.