### PR TITLE
Fix missing {{- end }} in ServiceAccount template

### DIFF
--- a/.changeset/tricky-tables-compare.md
+++ b/.changeset/tricky-tables-compare.md
@@ -1,0 +1,5 @@
+---
+"comet-site-v1": patch
+---
+
+Added missing {{- end }} to properly close the `with` block in the ServiceAccount template

--- a/charts/comet-site-v1/templates/rbac.yaml
+++ b/charts/comet-site-v1/templates/rbac.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
- Added missing {{- end }} to properly close the `with` block in the ServiceAccount template  
- Prevents Helm rendering errors due to unclosed block  
- Ensures correct YAML structure for annotations  