### PR TITLE
Add serviceAccountName configuration to site deployment

### DIFF
--- a/.changeset/silver-kiwis-call.md
+++ b/.changeset/silver-kiwis-call.md
@@ -1,0 +1,5 @@
+---
+"comet-site-v1": minor
+---
+
+Add serviceAccountName configuration to site deployment

--- a/charts/comet-site-v1/templates/deployment.yaml
+++ b/charts/comet-site-v1/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
+      serviceAccountName: {{ include "comet-site.serviceAccountName" . }}
       {{- if or (.Values.builder.enabled) (.Values.initContainer.enabled) }}
       initContainers:
         - name: {{ .Chart.Name }}-copy


### PR DESCRIPTION
- If `serviceAccountName` is not provided, it defaults to default.
- `serviceAccountName` is required for manually mounting tokens and linking the service account to the deployment. 
- `serviceAccountName` is already configured in api deployment: https://github.com/vivid-planet/comet-charts/blob/d848cf0fa8c6e08fbd3d412e2e3b11d51c6f9ca2/charts/comet-api-v1/templates/deployment.yaml#L39

OpenShift docs: https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/authentication_and_authorization/bound-service-account-tokens#bound-sa-tokens-configuring_bound-service-account-tokens
<img width="823" alt="Screenshot 2025-03-20 at 16 44 32" src="https://github.com/user-attachments/assets/f0d14832-5106-4f56-909d-a872c5c42f8e" />

