### PR TITLE
Manually mount service account token when created

### DIFF
--- a/.changeset/famous-teachers-retire.md
+++ b/.changeset/famous-teachers-retire.md
@@ -1,0 +1,6 @@
+---
+"comet-site-v1": minor
+"comet-api-v1": minor
+---
+
+Manually create and mount service account secrets in cron jobs for api and site

--- a/charts/comet-api-v1/templates/cron-jobs.yaml
+++ b/charts/comet-api-v1/templates/cron-jobs.yaml
@@ -80,8 +80,20 @@ spec:
                 - secretRef:
                     name:  {{ $val }}
                 {{- end }}
+              volumeMounts:
+                {{- if .Values.serviceAccount.create }}
+                - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+                  name: service-account
+                  readOnly: true
+                {{- end }}
               resources:
                 {{- $job.resources | default .Values.resources | toYaml | nindent 16 }}
+          volumes:
+            {{- if .Values.serviceAccount.create }}
+            - name: "service-account"
+              secret:
+                secretName: {{ include "comet-api.fullname" . }}-service-account-token
+            {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/comet-site-v1/templates/build-cron-job.yaml
+++ b/charts/comet-site-v1/templates/build-cron-job.yaml
@@ -99,9 +99,19 @@ spec:
                   name: generated-sites
                 - mountPath: /tmp
                   name: tmp
+                {{- if .Values.serviceAccount.create }}
+                - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+                  name: "service-account"
+                  readOnly: true
+                {{- end }}
               resources:
                 {{- toYaml .Values.builder.resources | nindent 16 }}
           volumes:
+            {{- if .Values.serviceAccount.create }}
+            - name: "service-account"
+              secret:
+                secretName: {{ include "comet-site.fullname" . }}-service-account-token
+            {{- end }}
             - name: document-root
               emptyDir: {}
             - name: tmp


### PR DESCRIPTION
-  Define a new volume for the service account token
- Mount the service account token volume in the container
- Ensure compatibility with `autoMountServiceAccountToken` behavior
- Manually create a service account secret and mount it in cron jobs for comet-api-v1 and comet-site-v1 charts instead of relying on `autoMountServiceAccountToken`

Related to: https://github.com/vivid-planet/comet-charts/pull/110 