### PR TITLE
Increase CPU limit from 1 to 2

### DIFF
--- a/.changeset/flat-jokes-cough.md
+++ b/.changeset/flat-jokes-cough.md
@@ -1,0 +1,8 @@
+---
+"comet-site-preview-v1": minor
+"comet-admin-v1": minor
+"comet-site-v1": minor
+"comet-api-v1": minor
+---
+
+Increase CPU limit from 1 to 2

--- a/charts/comet-admin-v1/values.yaml
+++ b/charts/comet-admin-v1/values.yaml
@@ -52,7 +52,7 @@ route:
 
 resources:
   limits:
-    cpu: 1
+    cpu: 2
     memory: 128Mi
   requests:
     cpu: 10m

--- a/charts/comet-api-v1/values.yaml
+++ b/charts/comet-api-v1/values.yaml
@@ -55,7 +55,7 @@ route:
 
 resources:
   limits:
-    cpu: 1
+    cpu: 2
     memory: 256Mi
   requests:
     cpu: 50m
@@ -64,7 +64,7 @@ resources:
 initContainer:
   resources:
     limits:
-      cpu: 1
+      cpu: 2
       memory: 256Mi
     requests:
       cpu: 100m

--- a/charts/comet-site-preview-v1/values.yaml
+++ b/charts/comet-site-preview-v1/values.yaml
@@ -24,7 +24,7 @@ service:
 resources:
   limits:
     memory: 200Mi
-    cpu: 1
+    cpu: 2
   requests:
     cpu: 50m
     memory: 200Mi
@@ -33,7 +33,7 @@ initContainer:
   resources:
     limits:
       memory: 512Mi
-      cpu: 1
+      cpu: 2
     requests:
       cpu: 50m
       memory: 512Mi

--- a/charts/comet-site-v1/values.yaml
+++ b/charts/comet-site-v1/values.yaml
@@ -33,7 +33,7 @@ metrics:
 resources:
   limits:
     memory: 200Mi
-    cpu: 1
+    cpu: 2
   requests:
     cpu: 50m
     memory: 200Mi
@@ -50,7 +50,7 @@ initContainer:
   resources:
     limits:
       memory: 512Mi
-      cpu: 1
+      cpu: 2
     requests:
       cpu: 50m
       memory: 512Mi


### PR DESCRIPTION
Previously, we set the cpu limit for our single threaded NodeJS applications to 1. But in kubernetes even single threaded applications can benefit from more than 1 cpu core. This way processes like garbage collections or kubernetes processes can be offloaded to an additional core, keeping the main core free for the NodeJS application.
We did some tests and came to the conclusion that a cpu limit of 2 is the sweet spot.