### PR TITLE
Increase API memory by 50% to 384Mi

### DIFF
--- a/.changeset/loud-readers-count.md
+++ b/.changeset/loud-readers-count.md
@@ -1,0 +1,8 @@
+---
+"comet-api-v1": patch
+"comet-api-v2": patch
+---
+
+Increase default api memory to 384Mi
+
+With COMET v8 api memory requirements have risen. The api tends to go OOM even for pristine v8 projects with just 256Mi.

--- a/charts/comet-api-v1/values.yaml
+++ b/charts/comet-api-v1/values.yaml
@@ -59,10 +59,10 @@ route:
 resources:
   limits:
     cpu: 2
-    memory: 256Mi
+    memory: 384Mi
   requests:
     cpu: 50m
-    memory: 256Mi
+    memory: 384Mi
 
 initContainer:
   resources:

--- a/charts/comet-api-v2/values.yaml
+++ b/charts/comet-api-v2/values.yaml
@@ -59,10 +59,10 @@ route:
 resources:
   limits:
     cpu: 2
-    memory: 256Mi
+    memory: 384Mi
   requests:
     cpu: 50m
-    memory: 256Mi
+    memory: 384Mi
 
 initContainers: []
 


### PR DESCRIPTION
Increase default api memory to 384Mi

With COMET v8 api memory requirements have risen. The api tends to go OOM even for pristine v8 projects with just 256Mi.

The deployed starter takes up to 256 and sometimes goes OOM:

<img width="814" height="408" alt="Bildschirmfoto 2025-12-15 um 13 05 29" src="https://github.com/user-attachments/assets/0e36ca2c-9e2c-4c00-9b10-8044040e3463" />

384Mi should be sufficient

---

https://vivid-planet.atlassian.net/browse/COM-2641