### PR TITLE
Allow overriding the comet-dxp.com/instance label via instanceNameOverride

### DIFF
--- a/.changeset/warm-dogs-laugh.md
+++ b/.changeset/warm-dogs-laugh.md
@@ -1,0 +1,7 @@
+---
+"comet-api-v1": minor
+"comet-api-v2": minor
+"comet-site-v1": minor
+---
+
+Allow overriding the `comet-dxp.com/instance` label via `instanceNameOverride` value

--- a/charts/comet-api-v1/templates/cron-jobs.yaml
+++ b/charts/comet-api-v1/templates/cron-jobs.yaml
@@ -10,7 +10,7 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   labels:
-    comet-dxp.com/instance: "{{ .Release.Name }}"
+    comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
     {{- include "comet-api.labels" . | nindent 4 }}
     {{- if $job.additionalLabels }}
       {{- tpl ($job.additionalLabels | toYaml) . | nindent 4 }}
@@ -28,7 +28,7 @@ spec:
       annotations:
         comet-dxp.com/trigger: "cronjob"
       labels:
-        comet-dxp.com/instance: "{{ .Release.Name }}"
+        comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
         comet-dxp.com/parent-cron-job: {{ print (include "comet-api.fullname" .) "-" $name | trunc 52 | trimSuffix "-" }}
     spec:
       backoffLimit: {{ $job.backoffLimit | default 1 }}

--- a/charts/comet-api-v1/templates/cron-jobs.yaml
+++ b/charts/comet-api-v1/templates/cron-jobs.yaml
@@ -10,7 +10,7 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   labels:
-    comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
+    comet-dxp.com/instance: "{{ $job.instanceNameOverride | default .Release.Name }}"
     {{- include "comet-api.labels" . | nindent 4 }}
     {{- if $job.additionalLabels }}
       {{- tpl ($job.additionalLabels | toYaml) . | nindent 4 }}
@@ -28,7 +28,7 @@ spec:
       annotations:
         comet-dxp.com/trigger: "cronjob"
       labels:
-        comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
+        comet-dxp.com/instance: "{{ $job.instanceNameOverride | default .Release.Name }}"
         comet-dxp.com/parent-cron-job: {{ print (include "comet-api.fullname" .) "-" $name | trunc 52 | trimSuffix "-" }}
     spec:
       backoffLimit: {{ $job.backoffLimit | default 1 }}

--- a/charts/comet-api-v1/values.yaml
+++ b/charts/comet-api-v1/values.yaml
@@ -1,5 +1,3 @@
-instanceNameOverride: ""
-
 replicaCount: 1
 
 authproxy:
@@ -113,6 +111,7 @@ cronJobs:
     schedule: "*/15 * * * *"
     additionalLabels:
       comet-dxp.com/build-checker: "true"
+    instanceNameOverride: ""
     additionalAnnotations: {}
     additionalPodLabels: {}
     activeDeadlineSeconds: 600
@@ -128,6 +127,7 @@ cronJobs:
     command: "npm run console:prod migrateBlocks && npm run console:prod createBlockIndexViews"
     schedule: "0 0 30 2 *" # 30th of February, will never run automatically
     activeDeadlineSeconds: 1200
+    instanceNameOverride: ""
     additionalAnnotations: {}
     additionalLabels: {}
     additionalPodLabels: {}
@@ -144,6 +144,7 @@ cronJobs:
     command: "npm run fixtures:prod"
     schedule: "0 0 30 2 *" # 30th of February, will never run automatically
     activeDeadlineSeconds: 1200
+    instanceNameOverride: ""
     additionalAnnotations: {}
     additionalLabels: {}
     additionalPodLabels: {}

--- a/charts/comet-api-v1/values.yaml
+++ b/charts/comet-api-v1/values.yaml
@@ -1,3 +1,5 @@
+instanceNameOverride: ""
+
 replicaCount: 1
 
 authproxy:

--- a/charts/comet-api-v2/templates/cron-jobs.yaml
+++ b/charts/comet-api-v2/templates/cron-jobs.yaml
@@ -10,7 +10,7 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   labels:
-    comet-dxp.com/instance: "{{ .Release.Name }}"
+    comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
     {{- include "comet-api.labels" . | nindent 4 }}
     {{- if $job.additionalLabels }}
       {{- tpl ($job.additionalLabels | toYaml) . | nindent 4 }}
@@ -28,7 +28,7 @@ spec:
       annotations:
         comet-dxp.com/trigger: "cronjob"
       labels:
-        comet-dxp.com/instance: "{{ .Release.Name }}"
+        comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
         comet-dxp.com/parent-cron-job: {{ print (include "comet-api.fullname" .) "-" $name | trunc 52 | trimSuffix "-" }}
     spec:
       backoffLimit: {{ $job.backoffLimit | default 1 }}

--- a/charts/comet-api-v2/templates/cron-jobs.yaml
+++ b/charts/comet-api-v2/templates/cron-jobs.yaml
@@ -10,7 +10,7 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   labels:
-    comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
+    comet-dxp.com/instance: "{{ $job.instanceNameOverride | default .Release.Name }}"
     {{- include "comet-api.labels" . | nindent 4 }}
     {{- if $job.additionalLabels }}
       {{- tpl ($job.additionalLabels | toYaml) . | nindent 4 }}
@@ -28,7 +28,7 @@ spec:
       annotations:
         comet-dxp.com/trigger: "cronjob"
       labels:
-        comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
+        comet-dxp.com/instance: "{{ $job.instanceNameOverride | default .Release.Name }}"
         comet-dxp.com/parent-cron-job: {{ print (include "comet-api.fullname" .) "-" $name | trunc 52 | trimSuffix "-" }}
     spec:
       backoffLimit: {{ $job.backoffLimit | default 1 }}

--- a/charts/comet-api-v2/values.yaml
+++ b/charts/comet-api-v2/values.yaml
@@ -1,3 +1,5 @@
+instanceNameOverride: ""
+
 replicaCount: 1
 
 authproxy:

--- a/charts/comet-api-v2/values.yaml
+++ b/charts/comet-api-v2/values.yaml
@@ -1,5 +1,3 @@
-instanceNameOverride: ""
-
 replicaCount: 1
 
 authproxy:
@@ -115,6 +113,7 @@ cronJobs:
     schedule: "*/15 * * * *"
     additionalLabels:
       comet-dxp.com/build-checker: "true"
+    instanceNameOverride: ""
     additionalAnnotations: {}
     additionalPodLabels: {}
     activeDeadlineSeconds: 600
@@ -130,6 +129,7 @@ cronJobs:
     command: "npm run console:prod migrateBlocks && npm run console:prod createBlockIndexViews"
     schedule: "0 0 30 2 *" # 30th of February, will never run automatically
     activeDeadlineSeconds: 1200
+    instanceNameOverride: ""
     additionalAnnotations: {}
     additionalLabels: {}
     additionalPodLabels: {}
@@ -146,6 +146,7 @@ cronJobs:
     command: "npm run fixtures:prod"
     schedule: "0 0 30 2 *" # 30th of February, will never run automatically
     activeDeadlineSeconds: 1200
+    instanceNameOverride: ""
     additionalAnnotations: {}
     additionalLabels: {}
     additionalPodLabels: {}

--- a/charts/comet-site-v1/templates/build-cron-job.yaml
+++ b/charts/comet-site-v1/templates/build-cron-job.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "comet-site.fullname" . }}-build
   labels:
     comet-dxp.com/builder: "true"
-    comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
+    comet-dxp.com/instance: "{{ .Values.builder.instanceNameOverride | default .Release.Name }}"
     {{- include "comet-site.labels" . | nindent 4 }}
   annotations:
     comet-dxp.com/content-scope: '{{- toJson .Values.contentScope }}'
@@ -24,7 +24,7 @@ spec:
         comet-dxp.com/label: "{{ .Values.label }}"
       labels:
         comet-dxp.com/builder: "true"
-        comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
+        comet-dxp.com/instance: "{{ .Values.builder.instanceNameOverride | default .Release.Name }}"
         comet-dxp.com/parent-cron-job: {{ include "comet-site.fullname" . }}-build
         {{- include "comet-site.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/comet-site-v1/templates/build-cron-job.yaml
+++ b/charts/comet-site-v1/templates/build-cron-job.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "comet-site.fullname" . }}-build
   labels:
     comet-dxp.com/builder: "true"
-    comet-dxp.com/instance: "{{ .Release.Name }}"
+    comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
     {{- include "comet-site.labels" . | nindent 4 }}
   annotations:
     comet-dxp.com/content-scope: '{{- toJson .Values.contentScope }}'
@@ -24,7 +24,7 @@ spec:
         comet-dxp.com/label: "{{ .Values.label }}"
       labels:
         comet-dxp.com/builder: "true"
-        comet-dxp.com/instance: "{{ .Release.Name }}"
+        comet-dxp.com/instance: "{{ .Values.instanceNameOverride | default .Release.Name }}"
         comet-dxp.com/parent-cron-job: {{ include "comet-site.fullname" . }}-build
         {{- include "comet-site.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/comet-site-v1/values.yaml
+++ b/charts/comet-site-v1/values.yaml
@@ -1,5 +1,6 @@
 contentScope: {}
 label: ""
+instanceNameOverride: ""
 
 env:
   NODE_ENV: "production"

--- a/charts/comet-site-v1/values.yaml
+++ b/charts/comet-site-v1/values.yaml
@@ -1,6 +1,5 @@
 contentScope: {}
 label: ""
-instanceNameOverride: ""
 
 env:
   NODE_ENV: "production"
@@ -59,6 +58,7 @@ initContainer:
 
 builder:
   enabled: false
+  instanceNameOverride: ""
 
   schedule: "0 6 * * *"
 


### PR DESCRIPTION
This is necessary for a project of ours where a site has been split into a dedicated deployment.