### PR TITLE
Make tls optional for ingress chart

### DIFF
--- a/.changeset/optional-ingress-tls.md
+++ b/.changeset/optional-ingress-tls.md
@@ -1,0 +1,5 @@
+---
+"comet-ingress-v1": minor
+---
+
+Make TLS optional per ingress. Set `tls: false` on an ingress entry to create an HTTP-only ingress without a TLS section. Defaults to `true` for backward compatibility.

--- a/charts/comet-ingress-v1/templates/ingress.yaml
+++ b/charts/comet-ingress-v1/templates/ingress.yaml
@@ -35,6 +35,7 @@ spec:
           service:
             {{ $i.service | toYaml | nindent 12 }}
   {{- end }}
+  {{- if not (eq $i.tls false) }}
   tls:
     {{- if kindIs "slice" $i.hostname }}
     {{- range $j, $k := $i.hostname }}
@@ -47,5 +48,6 @@ spec:
       - {{ $i.hostname }}
       secretName: {{ $i.service.name }}-cert
     {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/comet-ingress-v1/values.yaml
+++ b/charts/comet-ingress-v1/values.yaml
@@ -12,6 +12,8 @@ annotations:
 #       name: comet-oauth2-proxy
 #       port:
 #         number: 3000
+#     # Set tls: false to disable TLS and serve over HTTP only (defaults to true)
+#     # tls: false
 #   - hostname: preview.comet-dxp.com
 #     service:
 #       name: comet-oauth2-proxy-preview


### PR DESCRIPTION
For internal ingresses tls is not always required. At the moment cert manager always wants to create certs for that ingresses and spams all logs with errors