### PR TITLE
feat:  Make the http section optional when no backend service is defined

### DIFF
--- a/.changeset/optional-ingress-service.md
+++ b/.changeset/optional-ingress-service.md
@@ -1,0 +1,7 @@
+---
+"comet-ingress-v1": minor
+---
+
+Make the http section optional per ingress entry. When `service` is omitted, the entire `http` block is skipped — only the host rule and TLS section are rendered. This is required because Kubernetes rejects path entries without a backend. TLS remains enabled; when no service is configured the `secretName` defaults to `<fullname>-<index>-cert` instead of `<service.name>-cert`.
+
+This allows using the ingress solely for TLS certificate provisioning via cert-manager, without routing any traffic to a backend service.

--- a/charts/comet-ingress-v1/templates/ingress.yaml
+++ b/charts/comet-ingress-v1/templates/ingress.yaml
@@ -17,6 +17,7 @@ spec:
   {{- if kindIs "slice" $i.hostname }}
   {{- range $k := $i.hostname }}
   - host: {{ $k }}
+    {{- if $i.service }}
     http:
       paths:
       - path: /
@@ -24,9 +25,11 @@ spec:
         backend:
           service:
             {{ $i.service | toYaml | nindent 12 }}
+    {{- end }}
   {{- end }}
   {{- else }}
   - host: {{ $i.hostname }}
+    {{- if $i.service }}
     http:
       paths:
       - path: /
@@ -34,6 +37,7 @@ spec:
         backend:
           service:
             {{ $i.service | toYaml | nindent 12 }}
+    {{- end }}
   {{- end }}
   {{- if not (eq $i.tls false) }}
   tls:
@@ -41,12 +45,12 @@ spec:
     {{- range $j, $k := $i.hostname }}
     - hosts:
       - {{ $k }}
-      secretName: {{ $i.service.name }}-{{ $j }}-cert
+      secretName: {{ if $i.service }}{{ $i.service.name }}-{{ $j }}-cert{{ else }}{{ include "comet-ingress.fullname" $ }}-{{ $index }}-{{ $j }}-cert{{ end }}
     {{- end }}
     {{- else }}
     - hosts:
       - {{ $i.hostname }}
-      secretName: {{ $i.service.name }}-cert
+      secretName: {{ if $i.service }}{{ $i.service.name }}-cert{{ else }}{{ include "comet-ingress.fullname" $ }}-{{ $index }}-cert{{ end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/comet-ingress-v1/templates/ingress.yaml
+++ b/charts/comet-ingress-v1/templates/ingress.yaml
@@ -45,12 +45,20 @@ spec:
     {{- range $j, $k := $i.hostname }}
     - hosts:
       - {{ $k }}
-      secretName: {{ if $i.service }}{{ $i.service.name }}-{{ $j }}-cert{{ else }}{{ include "comet-ingress.fullname" $ }}-{{ $index }}-{{ $j }}-cert{{ end }}
+      {{- if $i.service }}
+      secretName: {{ $i.service.name }}-{{ $j }}-cert
+      {{- else }}
+      secretName: {{ include "comet-ingress.fullname" $ }}-{{ $index }}-{{ $j }}-cert
+      {{- end }}
     {{- end }}
     {{- else }}
     - hosts:
       - {{ $i.hostname }}
-      secretName: {{ if $i.service }}{{ $i.service.name }}-cert{{ else }}{{ include "comet-ingress.fullname" $ }}-{{ $index }}-cert{{ end }}
+      {{- if $i.service }}
+      secretName: {{ $i.service.name }}-cert
+      {{- else }}
+      secretName: {{ include "comet-ingress.fullname" $ }}-{{ $index }}-cert
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/comet-ingress-v1/values.yaml
+++ b/charts/comet-ingress-v1/values.yaml
@@ -24,3 +24,7 @@ annotations:
 #       name: comet-site
 #       port:
 #         number: 3000
+#   # Ingress without a http section (e.g. for TLS certificate provisioning only):
+#   - hostname: cert-only.comet-dxp.com
+#     # service is omitted — no http sections are rendered
+#     # TLS is still enabled; secretName defaults to <fullname>-<index>-cert


### PR DESCRIPTION
- ingress.yaml: The http block is only rendered when `$i.service` is set. The TLS secretName falls back to `<fullname>-<index>-cert` when no service is specified — if a service is defined, the name remains identical to before `<service.name>-cert`. his allows setting up a project-specific cluster domain with an SSL certificate, e.g. for use in a CDN setup.

- values.yaml: Add a comment example for an ingress without a service.
