### PR TITLE
chore: integrate helmfmt for chart template formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,25 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install helmfmt
+        env:
+          HELMFMT_VERSION: v0.5.0
+        run: |
+          curl -fsSL "https://github.com/digitalstudium/helmfmt/releases/download/${HELMFMT_VERSION}/helmfmt_Linux_x86_64.tar.gz" \
+            | sudo tar -xzf - -C /usr/local/bin/ helmfmt
+
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
       - name: Run Prettier
         run: npx prettier -c .
+
+      - name: Run Helmfmt
+        run: |
+          set -e
+          fail=0
+          for chart in charts/*/; do
+            echo "Checking $chart"
+            helmfmt --check "$chart" || fail=1
+          done
+          exit $fail

--- a/.helmfmt
+++ b/.helmfmt
@@ -1,0 +1,32 @@
+{
+  "indent_size": 2,
+  "extensions": [".yaml", ".yml", ".tpl"],
+  "rules": {
+    "indent": {
+      "tpl": {
+        "disabled": true,
+        "exclude": []
+      },
+      "toYaml": {
+        "disabled": true,
+        "exclude": []
+      },
+      "template": {
+        "disabled": true,
+        "exclude": []
+      },
+      "include": {
+        "disabled": true,
+        "exclude": []
+      },
+      "printf": {
+        "disabled": false,
+        "exclude": []
+      },
+      "fail": {
+        "disabled": false,
+        "exclude": []
+      }
+    }
+  }
+}

--- a/charts/comet-admin-v1/templates/NOTES.txt
+++ b/charts/comet-admin-v1/templates/NOTES.txt
@@ -1,10 +1,10 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
+  {{- range $host := .Values.ingress.hosts }}
+    {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+    {{- end }}
   {{- end }}
-{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "comet-admin.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/comet-admin-v1/templates/_helpers.tpl
+++ b/charts/comet-admin-v1/templates/_helpers.tpl
@@ -11,23 +11,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "comet-admin.fullname" -}}
-{{- if .Values.fullnameOverride }}
+  {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "comet-admin.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -36,9 +36,9 @@ Common labels
 {{- define "comet-admin.labels" -}}
 helm.sh/chart: {{ include "comet-admin.chart" . }}
 {{ include "comet-admin.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/comet-admin-v1/templates/deployment.yaml
+++ b/charts/comet-admin-v1/templates/deployment.yaml
@@ -5,31 +5,31 @@ metadata:
   labels:
     {{- include "comet-admin.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "comet-admin.selectorMatchLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        {{- if .Values.image.pullSecret }}
+{{- if .Values.image.pullSecret }}
         checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- range $key, $val := .Values.podAnnotations }}
+{{- end }}
+{{- range $key, $val := .Values.podAnnotations }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
       labels:
         {{- include "comet-admin.selectorLabels" . | nindent 8 }}
-        {{- range $key, $val := .Values.additionalPodLabels }}
+{{- range $key, $val := .Values.additionalPodLabels }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
     spec:
-      {{- if .Values.image.pullSecret }}
+{{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ include "comet-admin.fullname" . }}-image-pull-secret
-      {{- end }}
+{{- end }}
       automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -37,21 +37,21 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+{{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+{{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
-            {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: {{ .Values.metrics.containerPorts.http }}
               protocol: TCP
-            {{- end }}
+{{- end }}
           env:
             - name: NODE_ENV
               value: "{{ .Values.nodeEnv }}"
@@ -59,10 +59,10 @@ spec:
               value: "{{ .Values.npmRun }}"
             - name: TZ
               value: "{{ .Values.timeZone }}"
-            {{- range $key, $val := .Values.env }}
+{{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
-            {{- end }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: /status/health
@@ -73,15 +73,15 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+{{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+{{- end }}

--- a/charts/comet-admin-v1/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/comet-admin-v1/templates/horizontal-pod-autoscaler.yaml
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-admin-v1/templates/ingress.yaml
+++ b/charts/comet-admin-v1/templates/ingress.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "comet-admin.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $val := .Values.ingress.annotations }}
+  {{- range $key, $val := .Values.ingress.annotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
 spec:
   ingressClassName: nginx
   rules:

--- a/charts/comet-admin-v1/templates/route.yaml
+++ b/charts/comet-admin-v1/templates/route.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "comet-admin.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $val := .Values.route.annotations }}
+  {{- range $key, $val := .Values.route.annotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
 spec:
   host: "{{ .Values.domain }}"
   port:

--- a/charts/comet-admin-v1/templates/service.yaml
+++ b/charts/comet-admin-v1/templates/service.yaml
@@ -11,11 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
     - name: metrics
       protocol: TCP
       port: {{ .Values.metrics.containerPorts.http }}
       targetPort: metrics
-    {{- end }}
+{{- end }}
   selector:
     {{- include "comet-admin.selectorLabels" . | nindent 4 }}

--- a/charts/comet-api-v1/templates/NOTES.txt
+++ b/charts/comet-api-v1/templates/NOTES.txt
@@ -1,10 +1,10 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
+  {{- range $host := .Values.ingress.hosts }}
+    {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+    {{- end }}
   {{- end }}
-{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "comet-api.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/comet-api-v1/templates/_helpers.tpl
+++ b/charts/comet-api-v1/templates/_helpers.tpl
@@ -11,23 +11,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "comet-api.fullname" -}}
-{{- if .Values.fullnameOverride }}
+  {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "comet-api.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -36,9 +36,9 @@ Common labels
 {{- define "comet-api.labels" -}}
 helm.sh/chart: {{ include "comet-api.chart" . }}
 {{ include "comet-api.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -64,9 +64,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "comet-api.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+  {{- if .Values.serviceAccount.create }}
 {{- default (include "comet-api.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
+  {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-api-v1/templates/cron-jobs.yaml
+++ b/charts/comet-api-v1/templates/cron-jobs.yaml
@@ -1,20 +1,20 @@
 {{- range $name, $job := .Values.cronJobs }}
-{{- with $ -}}
-{{- if or $job.enabled (not (hasKey $job "enabled")) }}
+  {{- with $ -}}
+    {{- if or $job.enabled (not (hasKey $job "enabled")) }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ print (include "comet-api.fullname" .) "-" $name | trunc 52 | trimSuffix "-" }}
   annotations:
-    {{- range $key, $val := $job.additionalAnnotations }}
+      {{- range $key, $val := $job.additionalAnnotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+      {{- end }}
   labels:
     comet-dxp.com/instance: "{{ $job.instanceNameOverride | default .Release.Name }}"
     {{- include "comet-api.labels" . | nindent 4 }}
-    {{- if $job.additionalLabels }}
+      {{- if $job.additionalLabels }}
       {{- tpl ($job.additionalLabels | toYaml) . | nindent 4 }}
-    {{- end }}
+      {{- end }}
 spec:
   schedule: {{ $job.schedule | quote }}
   suspend: {{ $job.suspend | default false }}
@@ -37,14 +37,14 @@ spec:
       template:
         metadata:
           labels:
-            {{- range $key, $val := $job.additionalPodLabels }}
+      {{- range $key, $val := $job.additionalPodLabels }}
             {{ $key }}: {{ $val | quote }}
-            {{- end }}
+      {{- end }}
         spec:
-          {{- if .Values.image.pullSecret }}
+      {{- if .Values.image.pullSecret }}
           imagePullSecrets:
             - name: {{ include "comet-api.fullname" . }}-image-pull-secret
-          {{- end }}
+      {{- end }}
           restartPolicy: {{ $job.restartPolicy | default "Never" }}
           serviceAccountName: {{ include "comet-api.serviceAccountName" . }}
           securityContext:
@@ -54,52 +54,52 @@ spec:
             - name: {{ .Chart.Name }}-cronjob-{{ $name }}
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}
-              {{- if .Values.image.tag }}
+      {{- if .Values.image.tag }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-              {{- else }}
+      {{- else }}
               image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-              {{- end }}
+      {{- end }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["bash", "-c", {{ $job.command }}]
-              {{- if $job.env }}
+      {{- if $job.env }}
               env:
-                {{- range $key, $val := $job.env }}
+        {{- range $key, $val := $job.env }}
                 - name: {{ $key }}
                   value: {{ $val | quote }}
-                {{- end }}
-              {{- end }}
+        {{- end }}
+      {{- end }}
               envFrom:
-                {{- if .Values.env }}
+      {{- if .Values.env }}
                 - configMapRef:
                     name: {{ include "comet-api.fullname" . }}
-                {{- end }}
-                {{- range $key, $val := .Values.additionalConfigMapNames }}
+      {{- end }}
+      {{- range $key, $val := .Values.additionalConfigMapNames }}
                 - configMapRef:
                     name:  {{ $val }}
-                {{- end }}
-                {{- if .Values.secrets }}
+      {{- end }}
+      {{- if .Values.secrets }}
                 - secretRef:
                     name: {{ include "comet-api.fullname" . }}
-                {{- end }}
-                {{- range $key, $val := .Values.additionalSecretNames }}
+      {{- end }}
+      {{- range $key, $val := .Values.additionalSecretNames }}
                 - secretRef:
                     name:  {{ $val }}
-                {{- end }}
+      {{- end }}
               volumeMounts:
-                {{- if .Values.serviceAccount.create }}
+      {{- if .Values.serviceAccount.create }}
                 - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
                   name: service-account
                   readOnly: true
-                {{- end }}
+      {{- end }}
               resources:
                 {{- $job.resources | default .Values.resources | toYaml | nindent 16 }}
           volumes:
-            {{- if .Values.serviceAccount.create }}
+      {{- if .Values.serviceAccount.create }}
             - name: "service-account"
               secret:
                 secretName: {{ include "comet-api.fullname" . }}-service-account-token
-            {{- end }}
+      {{- end }}
 ---
-{{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/charts/comet-api-v1/templates/deployment.yaml
+++ b/charts/comet-api-v1/templates/deployment.yaml
@@ -5,37 +5,37 @@ metadata:
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "comet-api.selectorMatchLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        {{- if .Values.env }}
+{{- if .Values.env }}
         checksum/config-map: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
-        {{- end }}
-        {{- if .Values.image.pullSecret }}
+{{- end }}
+{{- if .Values.image.pullSecret }}
         checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- range $key, $val := .Values.podAnnotations }}
+{{- end }}
+{{- range $key, $val := .Values.podAnnotations }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
       labels:
         {{- include "comet-api.selectorLabels" . | nindent 8 }}
-        {{- range $key, $val := .Values.additionalPodLabels }}
+{{- range $key, $val := .Values.additionalPodLabels }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
     spec:
-      {{- if .Values.image.pullSecret }}
+{{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ include "comet-api.fullname" . }}-image-pull-secret
-      {{- end }}
+{{- end }}
       serviceAccountName: {{ include "comet-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -44,38 +44,38 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+{{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+{{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPorts.http }}
               protocol: TCP
-            {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: {{ .Values.metrics.containerPorts.http }}
               protocol: TCP
-            {{- end }}
+{{- end }}
           envFrom:
-            {{- if .Values.env }}
+{{- if .Values.env }}
             - configMapRef:
                 name: {{ include "comet-api.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalConfigMapNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalConfigMapNames }}
             - configMapRef:
                 name:  {{ $val }}
-            {{- end }}
-            {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
             - secretRef:
                 name: {{ include "comet-api.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalSecretNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalSecretNames }}
             - secretRef:
                 name:  {{ $val }}
-            {{- end }}
+{{- end }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:
@@ -87,59 +87,59 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
-            {{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccount.create }}
             - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
               name: service-account
               readOnly: true
-            {{- end }}
+{{- end }}
       initContainers:
         - name: {{ .Chart.Name }}-migrations
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+{{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+{{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["bash", "-c", {{ .Values.migrateCommand }}]
           envFrom:
-            {{- if .Values.env }}
+{{- if .Values.env }}
             - configMapRef:
                 name: {{ include "comet-api.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalConfigMapNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalConfigMapNames }}
             - configMapRef:
                 name:  {{ $val }}
-            {{- end }}
-            {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
             - secretRef:
                 name: {{ include "comet-api.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalSecretNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalSecretNames }}
             - secretRef:
                 name:  {{ $val }}
-            {{- end }}
+{{- end }}
           resources:
             {{- toYaml .Values.initContainer.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+{{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+{{- end }}
       volumes:
         - name: tmp
           emptyDir:
             sizeLimit: "1Gi"
-        {{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccount.create }}
         - name: "service-account"
           secret:
             secretName: {{ include "comet-api.fullname" . }}-service-account-token
-        {{- end }}
+{{- end }}

--- a/charts/comet-api-v1/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/comet-api-v1/templates/horizontal-pod-autoscaler.yaml
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-api-v1/templates/ingress.yaml
+++ b/charts/comet-api-v1/templates/ingress.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $val := .Values.ingress.annotations }}
+  {{- range $key, $val := .Values.ingress.annotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
 spec:
   ingressClassName: nginx
   rules:

--- a/charts/comet-api-v1/templates/route.yaml
+++ b/charts/comet-api-v1/templates/route.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $val := .Values.route.annotations }}
+  {{- range $key, $val := .Values.route.annotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
 spec:
   host: "{{ .Values.domain }}"
   port:

--- a/charts/comet-api-v1/templates/service.yaml
+++ b/charts/comet-api-v1/templates/service.yaml
@@ -11,11 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
     - name: metrics
       protocol: TCP
       port: {{ .Values.metrics.containerPorts.http }}
       targetPort: metrics
-    {{- end }}
+{{- end }}
   selector:
     {{- include "comet-api.selectorLabels" . | nindent 4 }}

--- a/charts/comet-api-v2/templates/NOTES.txt
+++ b/charts/comet-api-v2/templates/NOTES.txt
@@ -1,10 +1,10 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
+  {{- range $host := .Values.ingress.hosts }}
+    {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+    {{- end }}
   {{- end }}
-{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "comet-api.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/comet-api-v2/templates/_helpers.tpl
+++ b/charts/comet-api-v2/templates/_helpers.tpl
@@ -11,23 +11,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "comet-api.fullname" -}}
-{{- if .Values.fullnameOverride }}
+  {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "comet-api.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -36,9 +36,9 @@ Common labels
 {{- define "comet-api.labels" -}}
 helm.sh/chart: {{ include "comet-api.chart" . }}
 {{ include "comet-api.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -64,9 +64,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "comet-api.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+  {{- if .Values.serviceAccount.create }}
 {{- default (include "comet-api.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
+  {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-api-v2/templates/cron-jobs.yaml
+++ b/charts/comet-api-v2/templates/cron-jobs.yaml
@@ -1,20 +1,20 @@
 {{- range $name, $job := .Values.cronJobs }}
-{{- with $ -}}
-{{- if or $job.enabled (not (hasKey $job "enabled")) }}
+  {{- with $ -}}
+    {{- if or $job.enabled (not (hasKey $job "enabled")) }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ print (include "comet-api.fullname" .) "-" $name | trunc 52 | trimSuffix "-" }}
   annotations:
-    {{- range $key, $val := $job.additionalAnnotations }}
+      {{- range $key, $val := $job.additionalAnnotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+      {{- end }}
   labels:
     comet-dxp.com/instance: "{{ $job.instanceNameOverride | default .Release.Name }}"
     {{- include "comet-api.labels" . | nindent 4 }}
-    {{- if $job.additionalLabels }}
+      {{- if $job.additionalLabels }}
       {{- tpl ($job.additionalLabels | toYaml) . | nindent 4 }}
-    {{- end }}
+      {{- end }}
 spec:
   schedule: {{ $job.schedule | quote }}
   suspend: {{ $job.suspend | default false }}
@@ -37,14 +37,14 @@ spec:
       template:
         metadata:
           labels:
-            {{- range $key, $val := $job.additionalPodLabels }}
+      {{- range $key, $val := $job.additionalPodLabels }}
             {{ $key }}: {{ $val | quote }}
-            {{- end }}
+      {{- end }}
         spec:
-          {{- if .Values.image.pullSecret }}
+      {{- if .Values.image.pullSecret }}
           imagePullSecrets:
             - name: {{ include "comet-api.fullname" . }}-image-pull-secret
-          {{- end }}
+      {{- end }}
           restartPolicy: {{ $job.restartPolicy | default "Never" }}
           serviceAccountName: {{ include "comet-api.serviceAccountName" . }}
           securityContext:
@@ -54,52 +54,52 @@ spec:
             - name: {{ .Chart.Name }}-cronjob-{{ $name }}
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}
-              {{- if .Values.image.tag }}
+      {{- if .Values.image.tag }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-              {{- else }}
+      {{- else }}
               image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-              {{- end }}
+      {{- end }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["bash", "-c", {{ $job.command }}]
-              {{- if $job.env }}
+      {{- if $job.env }}
               env:
-                {{- range $key, $val := $job.env }}
+        {{- range $key, $val := $job.env }}
                 - name: {{ $key }}
                   value: {{ $val | quote }}
-                {{- end }}
-              {{- end }}
+        {{- end }}
+      {{- end }}
               envFrom:
-                {{- if .Values.env }}
+      {{- if .Values.env }}
                 - configMapRef:
                     name: {{ include "comet-api.fullname" . }}
-                {{- end }}
-                {{- range $key, $val := .Values.additionalConfigMapNames }}
+      {{- end }}
+      {{- range $key, $val := .Values.additionalConfigMapNames }}
                 - configMapRef:
                     name:  {{ $val }}
-                {{- end }}
-                {{- if .Values.secrets }}
+      {{- end }}
+      {{- if .Values.secrets }}
                 - secretRef:
                     name: {{ include "comet-api.fullname" . }}
-                {{- end }}
-                {{- range $key, $val := .Values.additionalSecretNames }}
+      {{- end }}
+      {{- range $key, $val := .Values.additionalSecretNames }}
                 - secretRef:
                     name:  {{ $val }}
-                {{- end }}
+      {{- end }}
               volumeMounts:
-                {{- if .Values.serviceAccount.create }}
+      {{- if .Values.serviceAccount.create }}
                 - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
                   name: service-account
                   readOnly: true
-                {{- end }}
+      {{- end }}
               resources:
                 {{- $job.resources | default .Values.resources | toYaml | nindent 16 }}
           volumes:
-            {{- if .Values.serviceAccount.create }}
+      {{- if .Values.serviceAccount.create }}
             - name: "service-account"
               secret:
                 secretName: {{ include "comet-api.fullname" . }}-service-account-token
-            {{- end }}
+      {{- end }}
 ---
-{{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/charts/comet-api-v2/templates/deployment.yaml
+++ b/charts/comet-api-v2/templates/deployment.yaml
@@ -5,37 +5,37 @@ metadata:
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "comet-api.selectorMatchLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        {{- if .Values.env }}
+{{- if .Values.env }}
         checksum/config-map: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
-        {{- end }}
-        {{- if .Values.image.pullSecret }}
+{{- end }}
+{{- if .Values.image.pullSecret }}
         checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- range $key, $val := .Values.podAnnotations }}
+{{- end }}
+{{- range $key, $val := .Values.podAnnotations }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
       labels:
         {{- include "comet-api.selectorLabels" . | nindent 8 }}
-        {{- range $key, $val := .Values.additionalPodLabels }}
+{{- range $key, $val := .Values.additionalPodLabels }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
     spec:
-      {{- if .Values.image.pullSecret }}
+{{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ include "comet-api.fullname" . }}-image-pull-secret
-      {{- end }}
+{{- end }}
       serviceAccountName: {{ include "comet-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -44,38 +44,38 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+{{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+{{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPorts.http }}
               protocol: TCP
-            {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: {{ .Values.metrics.containerPorts.http }}
               protocol: TCP
-            {{- end }}
+{{- end }}
           envFrom:
-            {{- if .Values.env }}
+{{- if .Values.env }}
             - configMapRef:
                 name: {{ include "comet-api.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalConfigMapNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalConfigMapNames }}
             - configMapRef:
                 name:  {{ $val }}
-            {{- end }}
-            {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
             - secretRef:
                 name: {{ include "comet-api.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalSecretNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalSecretNames }}
             - secretRef:
                 name:  {{ $val }}
-            {{- end }}
+{{- end }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:
@@ -87,33 +87,33 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
-            {{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccount.create }}
             - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
               name: service-account
               readOnly: true
-            {{- end }}
-      {{- with .Values.initContainers }}
+{{- end }}
+{{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.nodeSelector }}
+{{- end }}
+{{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+{{- end }}
       volumes:
         - name: tmp
           emptyDir:
             sizeLimit: "1Gi"
-        {{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccount.create }}
         - name: "service-account"
           secret:
             secretName: {{ include "comet-api.fullname" . }}-service-account-token
-        {{- end }}
+{{- end }}

--- a/charts/comet-api-v2/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/comet-api-v2/templates/horizontal-pod-autoscaler.yaml
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-api-v2/templates/ingress.yaml
+++ b/charts/comet-api-v2/templates/ingress.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $val := .Values.ingress.annotations }}
+  {{- range $key, $val := .Values.ingress.annotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
 spec:
   ingressClassName: nginx
   rules:

--- a/charts/comet-api-v2/templates/migrations-job.yaml
+++ b/charts/comet-api-v2/templates/migrations-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.migration.enabled }}
-{{- if .Values.image.pullSecret }}
+  {{- if .Values.image.pullSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,9 +13,9 @@ metadata:
 data:
   .dockerconfigjson: {{ required "Missing image.pullSecret" .Values.image.pullSecret }}
 type: kubernetes.io/dockerconfigjson
-{{- end }}
+  {{- end }}
 ---
-{{- if .Values.secrets }}
+  {{- if .Values.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -28,12 +28,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation # Remove the secret before hook creation
 type: Opaque
 stringData:
-  {{- range $key, $val := .Values.secrets }}
+    {{- range $key, $val := .Values.secrets }}
   {{ $key }}: {{ $val | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
 ---
-{{- if .Values.env }}
+  {{- if .Values.env }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -46,10 +46,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation # Remove the secret before hook creation
 data:
   HELM_RELEASE: "{{ .Release.Name }}"
-  {{- range $key, $val := .Values.env }}
+    {{- range $key, $val := .Values.env }}
   {{ $key }}: {{ $val | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -64,38 +64,38 @@ spec:
   template:
     spec:
       restartPolicy: Never # Do not restart the job on failure
-      {{- if .Values.image.pullSecret }}
+  {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ include "comet-api.fullname" . }}-migrations-image-pull-secret
-      {{- end }}
+  {{- end }}
       containers:
         - name: {{ .Chart.Name }}-migrations
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+  {{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+  {{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+  {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["bash", "-c", {{ .Values.migration.command }}]
           envFrom:
-            {{- if .Values.env }}
+  {{- if .Values.env }}
             - configMapRef:
                 name: {{ include "comet-api.fullname" . }}-migrations
-            {{- end }}
-            {{- range $key, $val := .Values.additionalConfigMapNames }}
+  {{- end }}
+  {{- range $key, $val := .Values.additionalConfigMapNames }}
             - configMapRef:
                 name: {{ $val }}
-            {{- end }}
-            {{- if .Values.secrets }}
+  {{- end }}
+  {{- if .Values.secrets }}
             - secretRef:
                 name: {{ include "comet-api.fullname" . }}-migrations
-            {{- end }}
-            {{- range $key, $val := .Values.additionalSecretNames }}
+  {{- end }}
+  {{- range $key, $val := .Values.additionalSecretNames }}
             - secretRef:
                 name: {{ $val }}
-            {{- end }}
+  {{- end }}
           resources:
             {{- toYaml .Values.migration.resources | nindent 12 }}
-  {{- end}}
+{{- end}}

--- a/charts/comet-api-v2/templates/route.yaml
+++ b/charts/comet-api-v2/templates/route.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $val := .Values.route.annotations }}
+  {{- range $key, $val := .Values.route.annotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
 spec:
   host: "{{ .Values.domain }}"
   port:

--- a/charts/comet-api-v2/templates/service.yaml
+++ b/charts/comet-api-v2/templates/service.yaml
@@ -11,11 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
     - name: metrics
       protocol: TCP
       port: {{ .Values.metrics.containerPorts.http }}
       targetPort: metrics
-    {{- end }}
+{{- end }}
   selector:
     {{- include "comet-api.selectorLabels" . | nindent 4 }}

--- a/charts/comet-ingress-v1/templates/_helpers.tpl
+++ b/charts/comet-ingress-v1/templates/_helpers.tpl
@@ -11,23 +11,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "comet-ingress.fullname" -}}
-{{- if .Values.fullnameOverride }}
+  {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "comet-ingress.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -36,9 +36,9 @@ Common labels
 {{- define "comet-ingress.labels" -}}
 helm.sh/chart: {{ include "comet-ingress.chart" . }}
 {{ include "comet-ingress.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -54,9 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "comet-ingress.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+  {{- if .Values.serviceAccount.create }}
 {{- default (include "comet-ingress.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
+  {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-ingress-v1/templates/ingress.yaml
+++ b/charts/comet-ingress-v1/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- range $index, $i := .Values.ingresses }}
-{{ if or (kindIs "string" $i.hostname) (gt (len $i.hostname) 0) }}
+  {{ if or (kindIs "string" $i.hostname) (gt (len $i.hostname) 0) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -14,52 +14,52 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  {{- if kindIs "slice" $i.hostname }}
-  {{- range $k := $i.hostname }}
-  - host: {{ $k }}
-    {{- if $i.service }}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            {{ $i.service | toYaml | nindent 12 }}
-    {{- end }}
-  {{- end }}
-  {{- else }}
-  - host: {{ $i.hostname }}
-    {{- if $i.service }}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            {{ $i.service | toYaml | nindent 12 }}
-    {{- end }}
-  {{- end }}
-  {{- if not (eq $i.tls false) }}
-  tls:
     {{- if kindIs "slice" $i.hostname }}
-    {{- range $j, $k := $i.hostname }}
+      {{- range $k := $i.hostname }}
+  - host: {{ $k }}
+        {{- if $i.service }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            {{ $i.service | toYaml | nindent 12 }}
+        {{- end }}
+      {{- end }}
+    {{- else }}
+  - host: {{ $i.hostname }}
+      {{- if $i.service }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            {{ $i.service | toYaml | nindent 12 }}
+      {{- end }}
+    {{- end }}
+    {{- if not (eq $i.tls false) }}
+  tls:
+      {{- if kindIs "slice" $i.hostname }}
+        {{- range $j, $k := $i.hostname }}
     - hosts:
       - {{ $k }}
-      {{- if $i.service }}
+          {{- if $i.service }}
       secretName: {{ $i.service.name }}-{{ $j }}-cert
-      {{- else }}
+          {{- else }}
       secretName: {{ include "comet-ingress.fullname" $ }}-{{ $index }}-{{ $j }}-cert
-      {{- end }}
-    {{- end }}
-    {{- else }}
+          {{- end }}
+        {{- end }}
+      {{- else }}
     - hosts:
       - {{ $i.hostname }}
-      {{- if $i.service }}
+        {{- if $i.service }}
       secretName: {{ $i.service.name }}-cert
-      {{- else }}
+        {{- else }}
       secretName: {{ include "comet-ingress.fullname" $ }}-{{ $index }}-cert
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/comet-keda-v1/templates/_helpers.tpl
+++ b/charts/comet-keda-v1/templates/_helpers.tpl
@@ -11,23 +11,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "comet-keda.fullname" -}}
-{{- if .Values.fullnameOverride }}
+  {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "comet-keda.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -36,9 +36,9 @@ Common labels
 {{- define "comet-keda.labels" -}}
 helm.sh/chart: {{ include "comet-keda.chart" . }}
 {{ include "comet-keda.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -54,9 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "comet-keda.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+  {{- if .Values.serviceAccount.create }}
 {{- default (include "comet-keda.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
+  {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-keda-v1/templates/http-scaled-object.yaml
+++ b/charts/comet-keda-v1/templates/http-scaled-object.yaml
@@ -1,5 +1,5 @@
 {{- range $index, $i := .Values.httpScaledObjects }}
-{{ if or (kindIs "string" $i.hostname) (gt (len $i.hostname) 0) }}
+  {{ if or (kindIs "string" $i.hostname) (gt (len $i.hostname) 0) }}
 ---
 apiVersion: http.keda.sh/v1alpha1
 kind: HTTPScaledObject
@@ -13,13 +13,13 @@ metadata:
     {{- end }}
 spec:
   hosts:
-  {{- if kindIs "slice" $i.hostname }}
-    {{- range $k := $i.hostname }}
+    {{- if kindIs "slice" $i.hostname }}
+      {{- range $k := $i.hostname }}
     - {{ $k }}
-    {{- end }}
-  {{- else }}
+      {{- end }}
+    {{- else }}
     - {{ $i.hostname }}
-  {{- end }}
+    {{- end }}
   pathPrefixes:
     {{- if kindIs "slice" $i.pathPrefixes }}
       {{- range $k := $i.pathPrefixes }}
@@ -43,5 +43,5 @@ spec:
       granularity: {{ $i.scalingMetric.requestRate.granularity | default "1s" }}
       targetValue: {{ $i.scalingMetric.requestRate.targetValue | default 100 }}
       window: {{ $i.scalingMetric.requestRate.window | default "1m" }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-site-preview-v1/templates/_helpers.tpl
+++ b/charts/comet-site-preview-v1/templates/_helpers.tpl
@@ -11,23 +11,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "comet-site-preview.fullname" -}}
-{{- if .Values.fullnameOverride }}
+  {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "comet-site-preview.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -36,9 +36,9 @@ Common labels
 {{- define "comet-site-preview.labels" -}}
 helm.sh/chart: {{ include "comet-site-preview.chart" . }}
 {{ include "comet-site-preview.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -57,9 +57,9 @@ Prelogin Common labels
 {{- define "comet-site-preview.prelogin.labels" -}}
 helm.sh/chart: {{ include "comet-site-preview.chart" . }}
 {{ include "comet-site-preview.prelogin.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/comet-site-preview-v1/templates/deployment.yaml
+++ b/charts/comet-site-preview-v1/templates/deployment.yaml
@@ -12,25 +12,25 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.env }}
+{{- if .Values.env }}
         checksum/config-map: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
-        {{- end }}
-        {{- if .Values.image.pullSecret }}
+{{- end }}
+{{- if .Values.image.pullSecret }}
         checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- end }}
+{{- end }}
       labels:
         {{- include "comet-site-preview.selectorLabels" . | nindent 8 }}
-        {{- range $key, $val := .Values.additionalPodLabels }}
+{{- range $key, $val := .Values.additionalPodLabels }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
     spec:
-      {{- if .Values.image.pullSecret }}
+{{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ include "comet-site-preview.fullname" . }}-image-pull-secret
-      {{- end }}
+{{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
@@ -38,30 +38,30 @@ spec:
         - name: {{ .Chart.Name }}-build
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+{{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+{{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/bash", "-c", "next build"]
           envFrom:
-            {{- if .Values.env }}
+{{- if .Values.env }}
             - configMapRef:
                 name: {{ include "comet-site-preview.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalConfigMapNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalConfigMapNames }}
             - configMapRef:
                 name:  {{ $val }}
-            {{- end }}
-            {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
             - secretRef:
                 name: {{ include "comet-site-preview.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalSecretNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalSecretNames }}
             - secretRef:
                 name:  {{ $val }}
-            {{- end }}
+{{- end }}
           volumeMounts:
             - mountPath: /opt/app-root/src/.next
               name: document-root
@@ -71,29 +71,29 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+{{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+{{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
-            {{- if .Values.env }}
+{{- if .Values.env }}
             - configMapRef:
                 name: {{ include "comet-site-preview.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalConfigMapNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalConfigMapNames }}
             - configMapRef:
                 name:  {{ $val }}
-            {{- end }}
-            {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
             - secretRef:
                 name: {{ include "comet-site-preview.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalSecretNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalSecretNames }}
             - secretRef:
                 name:  {{ $val }}
-            {{- end }}
+{{- end }}
           env:
             - name: NPM_RUN
               value: "{{ .Values.npmRun }}"
@@ -114,18 +114,18 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+{{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.affinity }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+{{- end }}
       volumes:
         - name: document-root
           emptyDir: {}

--- a/charts/comet-site-v1/templates/_helpers.tpl
+++ b/charts/comet-site-v1/templates/_helpers.tpl
@@ -11,23 +11,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "comet-site.fullname" -}}
-{{- if .Values.fullnameOverride }}
+  {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "comet-site.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -36,9 +36,9 @@ Common labels
 {{- define "comet-site.labels" -}}
 helm.sh/chart: {{ include "comet-site.chart" . }}
 {{ include "comet-site.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -66,9 +66,9 @@ Prelogin Common labels
 {{- define "comet-site.prelogin.labels" -}}
 helm.sh/chart: {{ include "comet-site.chart" . }}
 {{ include "comet-site.prelogin.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -85,9 +85,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "comet-site.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+  {{- if .Values.serviceAccount.create }}
 {{- default (include "comet-site.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
+  {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-site-v1/templates/additional-ingresses.yaml
+++ b/charts/comet-site-v1/templates/additional-ingresses.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.ingress.enabled) (.Values.additionalDomains) -}}
-{{- range $index, $additionalDomain := (splitList "," .Values.additionalDomains) }}
+  {{- range $index, $additionalDomain := (splitList "," .Values.additionalDomains) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -18,6 +18,6 @@ spec:
   - hosts:
     - "{{ $additionalDomain }}"
     secretName: {{ include "comet-site.fullname" $ }}-additional-{{ $index }}-cert
-{{- end -}}
+  {{- end -}}
 {{- end -}}
  

--- a/charts/comet-site-v1/templates/build-cron-job.yaml
+++ b/charts/comet-site-v1/templates/build-cron-job.yaml
@@ -34,14 +34,14 @@ spec:
       template:
         metadata:
           labels:
-            {{- range $key, $val := .Values.builder.additionalPodLabels }}
+  {{- range $key, $val := .Values.builder.additionalPodLabels }}
             {{ $key }}: {{ $val | quote }}
-            {{- end }}
+  {{- end }}
         spec:
-          {{- if .Values.image.pullSecret }}
+  {{- if .Values.image.pullSecret }}
           imagePullSecrets:
             - name: {{ include "comet-site.fullname" . }}-image-pull-secret
-          {{- end }}
+  {{- end }}
           restartPolicy: "Never"
           serviceAccountName: {{ include "comet-site.serviceAccountName" . }}
           securityContext:
@@ -51,11 +51,11 @@ spec:
             - name: {{ .Chart.Name }}-build
               securityContext:
                 {{- toYaml .Values.builder.securityContext | nindent 16 }}
-              {{- if .Values.image.tag }}
+  {{- if .Values.image.tag }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-              {{- else }}
+  {{- else }}
               image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-              {{- end }}
+  {{- end }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["bash", "-c"]
               args:
@@ -72,26 +72,26 @@ spec:
               env:
                 - name: KUBECTL_VERSION
                   value: "{{ .Values.builder.kubectlVersion }}"
-              {{- with .Values.builder.extraEnv }}
+  {{- with .Values.builder.extraEnv }}
                 {{- toYaml . | nindent 16 }}
-              {{- end }}
+  {{- end }}
               envFrom:
-                {{- if .Values.env }}
+  {{- if .Values.env }}
                 - configMapRef:
                     name: {{ include "comet-site.fullname" . }}
-                {{- end }}
-                {{- range $key, $val := .Values.additionalConfigMapNames }}
+  {{- end }}
+  {{- range $key, $val := .Values.additionalConfigMapNames }}
                 - configMapRef:
                     name:  {{ $val }}
-                {{- end }}
-                {{- if .Values.secrets }}
+  {{- end }}
+  {{- if .Values.secrets }}
                 - secretRef:
                     name: {{ include "comet-site.fullname" . }}
-                {{- end }}
-                {{- range $key, $val := .Values.additionalSecretNames }}
+  {{- end }}
+  {{- range $key, $val := .Values.additionalSecretNames }}
                 - secretRef:
                     name:  {{ $val }}
-                {{- end }}
+  {{- end }}
               volumeMounts:
                 - mountPath: /opt/app-root/src/.next
                   name: document-root
@@ -99,30 +99,30 @@ spec:
                   name: generated-sites
                 - mountPath: /tmp
                   name: tmp
-                {{- if .Values.serviceAccount.create }}
+  {{- if .Values.serviceAccount.create }}
                 - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
                   name: "service-account"
                   readOnly: true
-                {{- end }}
+  {{- end }}
               resources:
                 {{- toYaml .Values.builder.resources | nindent 16 }}
           volumes:
-            {{- if .Values.serviceAccount.create }}
+  {{- if .Values.serviceAccount.create }}
             - name: "service-account"
               secret:
                 secretName: {{ include "comet-site.fullname" . }}-service-account-token
-            {{- end }}
+  {{- end }}
             - name: document-root
               emptyDir: {}
             - name: tmp
               emptyDir: {}
             - name: generated-sites
               persistentVolumeClaim:
-{{- if and .Values.pvc.create .Values.pvc.name }}
+  {{- if and .Values.pvc.create .Values.pvc.name }}
                 claimName: {{ .Values.pvc.name }}
-{{- else if .Values.pvc.create }}
+  {{- else if .Values.pvc.create }}
                 claimName: {{ include "comet-site.fullname" . }}-build
-{{- else }}
+  {{- else }}
                 claimName: {{ .Values.persistence.existingClaim }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-site-v1/templates/deployment.yaml
+++ b/charts/comet-site-v1/templates/deployment.yaml
@@ -5,51 +5,51 @@ metadata:
   labels:
     {{- include "comet-site.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "comet-site.selectorMatchLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        {{- if .Values.env }}
+{{- if .Values.env }}
         checksum/config-map: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
-        {{- end }}
-        {{- if .Values.image.pullSecret }}
+{{- end }}
+{{- if .Values.image.pullSecret }}
         checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- end }}
-        {{- range $key, $val := .Values.podAnnotations }}
+{{- end }}
+{{- range $key, $val := .Values.podAnnotations }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
       labels:
         {{- include "comet-site.selectorLabels" . | nindent 8 }}
-        {{- range $key, $val := .Values.additionalPodLabels }}
+{{- range $key, $val := .Values.additionalPodLabels }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+{{- end }}
     spec:
-      {{- if .Values.image.pullSecret }}
+{{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ include "comet-site.fullname" . }}-image-pull-secret
-      {{- end }}
+{{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
       serviceAccountName: {{ include "comet-site.serviceAccountName" . }}
-      {{- if or (.Values.builder.enabled) (.Values.initContainer.enabled) }}
+{{- if or (.Values.builder.enabled) (.Values.initContainer.enabled) }}
       initContainers:
         - name: {{ .Chart.Name }}-copy
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+  {{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+  {{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+  {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/bash", "-c"]
           args:
@@ -66,96 +66,96 @@ spec:
                 rm -r /tmp/site-build;
               fi;
           envFrom:
-            {{- if .Values.env }}
+  {{- if .Values.env }}
             - configMapRef:
                 name: {{ include "comet-site.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalConfigMapNames }}
+  {{- end }}
+  {{- range $key, $val := .Values.additionalConfigMapNames }}
             - configMapRef:
                 name:  {{ $val }}
-            {{- end }}
-            {{- if .Values.secrets }}
+  {{- end }}
+  {{- if .Values.secrets }}
             - secretRef:
                 name: {{ include "comet-site.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalSecretNames }}
+  {{- end }}
+  {{- range $key, $val := .Values.additionalSecretNames }}
             - secretRef:
                 name:  {{ $val }}
-            {{- end }}
-          {{- with .Values.initContainer.extraEnv }}
+  {{- end }}
+  {{- with .Values.initContainer.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+  {{- end }}
           volumeMounts:
-          {{- if .Values.builder.enabled }}
+  {{- if .Values.builder.enabled }}
             - mountPath: /mnt/generated-sites/
               name: generated-sites
             - mountPath: /tmp
               name: tmp
-          {{- end }}
-          {{- if .Values.mountEmptyDirAsNextFolder }}
+  {{- end }}
+  {{- if .Values.mountEmptyDirAsNextFolder }}
             - mountPath: /opt/app-root/src/.next
               name: document-root
-          {{- end }}
+  {{- end }}
           resources:
             {{- toYaml .Values.initContainer.resources | nindent 12 }}
-      {{- end }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.image.tag }}
+{{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
+{{- else }}
           image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
-          {{- end }}
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
-            {{- if .Values.env }}
+{{- if .Values.env }}
             - configMapRef:
                 name: {{ include "comet-site.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalConfigMapNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalConfigMapNames }}
             - configMapRef:
                 name:  {{ $val }}
-            {{- end }}
-            {{- if .Values.secrets }}
+{{- end }}
+{{- if .Values.secrets }}
             - secretRef:
                 name: {{ include "comet-site.fullname" . }}
-            {{- end }}
-            {{- range $key, $val := .Values.additionalSecretNames }}
+{{- end }}
+{{- range $key, $val := .Values.additionalSecretNames }}
             - secretRef:
                 name:  {{ $val }}
-            {{- end }}
+{{- end }}
           env:
             - name: NPM_RUN
               value: "{{ .Values.npmRun }}"
-          {{- with .Values.extraEnv }}
+{{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+{{- end }}
           volumeMounts:
-          {{- if .Values.builder.enabled }}
+{{- if .Values.builder.enabled }}
             - mountPath: /mnt/generated-sites/
               name: generated-sites
-          {{- end }}
-          {{- if .Values.mountEmptyDirAsNextFolder }}
+{{- end }}
+{{- if .Values.mountEmptyDirAsNextFolder }}
             - mountPath: /opt/app-root/src/.next
               name: document-root
-          {{- end }}
-          {{- if .Values.serviceAccount.create }}
+{{- end }}
+{{- if .Values.serviceAccount.create }}
             - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
               name: "service-account"
               readOnly: true
-          {{- end }}
+{{- end }}
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
-            {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: {{ .Values.metrics.containerPorts.http }}
               protocol: TCP
-            {{- end }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: /api/status
@@ -172,38 +172,38 @@ spec:
                 value: "{{ .Values.cdn.originHeader }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+{{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.affinity }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+{{- end }}
       volumes:
-        {{- if .Values.serviceAccount.create }}
+{{- if .Values.serviceAccount.create }}
         - name: "service-account"
           secret:
             secretName: {{ include "comet-site.fullname" . }}-service-account-token
-        {{- end }}
-    {{- if .Values.builder.enabled }}
+{{- end }}
+{{- if .Values.builder.enabled }}
         - name: generated-sites
           persistentVolumeClaim:
-          {{- if and .Values.pvc.create .Values.pvc.name }}
+  {{- if and .Values.pvc.create .Values.pvc.name }}
             claimName: {{ .Values.pvc.name }}
-          {{- else if .Values.pvc.create }}
+  {{- else if .Values.pvc.create }}
             claimName: {{ include "comet-site.fullname" . }}-build
-          {{- else }}
+  {{- else }}
             claimName: {{ .Values.persistence.existingClaim }}
-          {{- end }}
+  {{- end }}
         - name: tmp
           emptyDir: {}
-    {{- end }}
-    {{- if .Values.mountEmptyDirAsNextFolder }}
+{{- end }}
+{{- if .Values.mountEmptyDirAsNextFolder }}
         - name: document-root
           emptyDir: {}
-    {{- end }}
+{{- end }}

--- a/charts/comet-site-v1/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/comet-site-v1/templates/horizontal-pod-autoscaler.yaml
@@ -13,20 +13,20 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-site-v1/templates/main-ingress.yaml
+++ b/charts/comet-site-v1/templates/main-ingress.yaml
@@ -6,15 +6,15 @@ metadata:
   labels:
     {{- include "comet-site.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $val := .Values.ingress.annotations }}
+  {{- range $key, $val := .Values.ingress.annotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
 
 spec:
   ingressClassName: nginx
   rules:
   {{- if .Values.domains }}
-  {{- range .Values.domains }}
+    {{- range .Values.domains }}
   - host: "{{ . }}"
     http:
       paths:
@@ -25,7 +25,7 @@ spec:
             name: {{ include "comet-site.fullname" $ }}
             port:
               number: 3000
-  {{- end }}
+    {{- end }}
   {{- else if .Values.cdn.enabled }}
   - host: "{{ .Values.internalDomain }}"
   {{- else }}
@@ -37,24 +37,24 @@ spec:
         pathType: Prefix
         backend:
           service:
-          {{- if .Values.prelogin.enabled }}
+  {{- if .Values.prelogin.enabled }}
             name: {{ include "comet-site.fullname" . }}-prelogin
-          {{- else }}
+  {{- else }}
             name: {{ include "comet-site.fullname" . }}
-          {{- end }}
+  {{- end }}
             port:
               number: 3000
 
   tls:
   - hosts:
-{{- if .Values.domains }}
-  {{- range .Values.domains }}
+  {{- if .Values.domains }}
+    {{- range .Values.domains }}
     - "{{ . }}"
-  {{- end }}
-{{- else if .Values.cdn.enabled }}
+    {{- end }}
+  {{- else if .Values.cdn.enabled }}
     - "{{ .Values.internalDomain }}"
-{{- else }}
+  {{- else }}
     - "{{ .Values.domain }}"
-{{- end }}
+  {{- end }}
     secretName: {{ include "comet-site.fullname" . }}-main-cert
 {{- end }}

--- a/charts/comet-site-v1/templates/persistent-volume-claim.yaml
+++ b/charts/comet-site-v1/templates/persistent-volume-claim.yaml
@@ -9,9 +9,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "comet-site.labels" . | nindent 4 }}
-    {{- if .Values.pvc.additionalLabels }}
+  {{- if .Values.pvc.additionalLabels }}
     {{- toYaml .Values.pvc.additionalLabels | nindent 4 }}
-    {{- end }}
+  {{- end }}
   {{- with .Values.pvc.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -19,9 +19,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-{{- if .Values.pvc.storageClass }}
+  {{- if .Values.pvc.storageClass }}
   storageClassName: {{ .Values.pvc.storageClass }}
-{{- end }}
+  {{- end }}
   resources:
     requests:
       storage: 10Gi

--- a/charts/comet-site-v1/templates/prelogin-deployment.yml
+++ b/charts/comet-site-v1/templates/prelogin-deployment.yml
@@ -13,19 +13,19 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if and (.Values.prelogin.enabled) (.Values.prelogin.secrets) }}
+  {{- if and (.Values.prelogin.enabled) (.Values.prelogin.secrets) }}
         checksum/prelogin-secret: {{ include (print $.Template.BasePath "/prelogin-secret.yaml") . | sha256sum }}
-        {{- end }}
+  {{- end }}
       labels:
         {{- include "comet-site.prelogin.selectorLabels" . | nindent 8 }}
-        {{- range $key, $val := .Values.prelogin.additionalPodLabels }}
+  {{- range $key, $val := .Values.prelogin.additionalPodLabels }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+  {{- end }}
     spec:
-      {{- if .Values.image.pullSecret }}
+  {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ include "comet-site.fullname" . }}-image-pull-secret
-      {{- end }}
+  {{- end }}
       securityContext:
         {{- toYaml .Values.prelogin.podSecurityContext | nindent 8 }}
       automountServiceAccountToken: {{ .Values.prelogin.autoMountServiceAccountToken }}
@@ -33,21 +33,21 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.prelogin.securityContext | nindent 12 }}
-          {{- if .Values.prelogin.image.tag }}
+  {{- if .Values.prelogin.image.tag }}
           image: "{{ .Values.prelogin.image.repository }}:{{ .Values.prelogin.image.tag }}"
-          {{- else }}
+  {{- else }}
           image: "{{ .Values.prelogin.image.repository }}@{{ .Values.prelogin.image.hash }}"
-          {{- end }}
+  {{- end }}
           imagePullPolicy: {{ .Values.prelogin.image.pullPolicy }}
           env:
             -   name: NODE_ENV
                 value: "production"
             -   name: NPM_RUN
                 value: "start"
-            {{- range $key, $val := .Values.prelogin.env }}
+  {{- range $key, $val := .Values.prelogin.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
-            {{- end }}
+  {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "comet-site.fullname" . }}-prelogin
@@ -67,16 +67,16 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.prelogin.resources | nindent 12 }}
-      {{- with .Values.prelogin.nodeSelector }}
+  {{- with .Values.prelogin.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.prelogin.affinity }}
+  {{- end }}
+  {{- with .Values.prelogin.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.prelogin.tolerations }}
+  {{- end }}
+  {{- with .Values.prelogin.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-site-v1/templates/route.yaml
+++ b/charts/comet-site-v1/templates/route.yaml
@@ -6,33 +6,33 @@ metadata:
   labels:
     {{- include "comet-site.labels" . | nindent 4 }}
   annotations:
-    {{- range $key, $val := .Values.route.annotations }}
+  {{- range $key, $val := .Values.route.annotations }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
 spec:
-{{- if .Values.cdn.enabled }}
+  {{- if .Values.cdn.enabled }}
   host: "{{ .Values.internalDomain }}"
-{{- else }}
+  {{- else }}
   host: "{{ .Values.domain }}"
-{{- end }}
+  {{- end }}
   {{- if .Values.route.tls.enabled }}
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
   {{- end }}
-{{- if .Values.prelogin.enabled }}
+  {{- if .Values.prelogin.enabled }}
   port:
     targetPort: 3010
   to:
       kind: Service
       name: {{ include "comet-site.fullname" . }}-prelogin
       weight: 100
-{{ else }}
+  {{ else }}
   port:
     targetPort: 3000
   to:
     kind: Service
     name: {{ include "comet-site.fullname" . }}
     weight: 100
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/comet-site-v1/templates/service.yaml
+++ b/charts/comet-site-v1/templates/service.yaml
@@ -5,23 +5,23 @@ metadata:
   labels:
     {{- include "comet-site.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.service.sessionAffinityTimeoutSeconds }}
+{{- if .Values.service.sessionAffinityTimeoutSeconds }}
   sessionAffinity: ClientIP
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: {{ .Values.service.sessionAffinityTimeoutSeconds }}
-  {{- end }}
+{{- end }}
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
     - name: metrics
       protocol: TCP
       port: {{ .Values.metrics.containerPorts.http }}
       targetPort: metrics
-    {{- end }}
+{{- end }}
   selector:
     {{- include "comet-site.selectorLabels" . | nindent 4 }}

--- a/charts/imgproxy/templates/_helpers.tpl
+++ b/charts/imgproxy/templates/_helpers.tpl
@@ -7,7 +7,7 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "imgproxy.chart" -}}
-{{- printf "%s-%s" $.Chart.Name ($.Chart.Version  | replace "+" "_") -}}
+  {{- printf "%s-%s" $.Chart.Name ($.Chart.Version  | replace "+" "_") -}}
 {{- end -}}
 
 {{/*
@@ -15,7 +15,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "imgproxy.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+  {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- default (printf "%s-%s" .Release.Name $name) .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -23,32 +23,32 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Template to generate secrets for a private Docker repository for K8s to use
 */}}
 {{- define "imgproxy.imagePullSecrets" }}
-{{- with .Values.image.pullSecrets -}}
-{{- if .enabled }}
-{{- $username := required "image.pullSecrets.username" .username -}}
-{{- $registry := required "image.pullSecrets.registry" .registry -}}
-{{- $password := required "image.pullSecrets.password" .password -}}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $registry (printf "%s:%s" $username $password | b64enc) | b64enc }}
-{{- end }}
-{{- end -}}
+  {{- with .Values.image.pullSecrets -}}
+    {{- if .enabled }}
+      {{- $username := required "image.pullSecrets.username" .username -}}
+      {{- $registry := required "image.pullSecrets.registry" .registry -}}
+      {{- $password := required "image.pullSecrets.password" .password -}}
+      {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $registry (printf "%s:%s" $username $password | b64enc) | b64enc }}
+    {{- end }}
+  {{- end -}}
 {{- end -}}
 
 {{/*
 Template to decide if the serviceAccount must be built
 */}}
 {{- define "serviceAccount.enabled" }}
-{{- with .Values.resources.serviceAccount -}}
-{{-   $useExistingName := (empty .existingName | not) -}}
-{{-   $useIamRole := (empty .aws.iamRoleName | and (empty .aws.accountId) | not) -}}
-{{-   $useAnnotations := (empty .annotations | not) -}}
-{{-   if (and $useExistingName $useAnnotations) -}}
-{{-     fail "Cannot add annotations to the external service account (check .resources.serviceAccount)" -}}
-{{-   end -}}
-{{-   if (and $useExistingName $useIamRole) -}}
-{{-     fail "Cannot add IAM Role authentication to the external service account (check .resources.serviceAccount)" -}}
-{{-   end -}}
+  {{- with .Values.resources.serviceAccount -}}
+    {{-   $useExistingName := (empty .existingName | not) -}}
+    {{-   $useIamRole := (empty .aws.iamRoleName | and (empty .aws.accountId) | not) -}}
+    {{-   $useAnnotations := (empty .annotations | not) -}}
+    {{-   if (and $useExistingName $useAnnotations) -}}
+      {{-     fail "Cannot add annotations to the external service account (check .resources.serviceAccount)" -}}
+    {{-   end -}}
+    {{-   if (and $useExistingName $useIamRole) -}}
+      {{-     fail "Cannot add IAM Role authentication to the external service account (check .resources.serviceAccount)" -}}
+    {{-   end -}}
 {{-   (not $useExistingName | and (or $useAnnotations $useIamRole)) }}
-{{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
@@ -56,80 +56,80 @@ Template to generate service account annotation for AWS IAM Role
 https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
 */}}
 {{- define "aws.iamRoleAnnotation" }}
-{{- with .Values.resources.serviceAccount.aws -}}
-{{- $id := required "resources.serviceAccount.aws.accountId" .accountId -}}
-{{- $role := required "resources.serviceAccount.aws.iamRoleName" .iamRoleName -}}
-{{- $value := printf "arn:aws:iam::%s:role/%s" $id $role -}}
-{{- printf "eks.amazonaws.com/role-arn: %s" (quote $value) }}
-{{- end -}}
+  {{- with .Values.resources.serviceAccount.aws -}}
+    {{- $id := required "resources.serviceAccount.aws.accountId" .accountId -}}
+    {{- $role := required "resources.serviceAccount.aws.iamRoleName" .iamRoleName -}}
+    {{- $value := printf "arn:aws:iam::%s:role/%s" $id $role -}}
+    {{- printf "eks.amazonaws.com/role-arn: %s" (quote $value) }}
+  {{- end -}}
 {{- end -}}
 
 {{/* Name of the priority class */}}
 {{- define "imgproxy.resources.priorityClassName" }}
-    {{- with .Values.resources.deployment.priority }}
-       {{- $systemNames := list "set-cluster-critical" "set-node-critical" }}
-       {{- if (include "imgproxy.versions.priorityClass" $) }}
-            {{- $defaultName := (include "imgproxy.fullname" $ | printf "%s-priority") }}
-            {{- $name := default $defaultName .name }}
-            {{- if (has $name $systemNames | or .level | or .name) }}
+  {{- with .Values.resources.deployment.priority }}
+    {{- $systemNames := list "set-cluster-critical" "set-node-critical" }}
+    {{- if (include "imgproxy.versions.priorityClass" $) }}
+      {{- $defaultName := (include "imgproxy.fullname" $ | printf "%s-priority") }}
+      {{- $name := default $defaultName .name }}
+      {{- if (has $name $systemNames | or .level | or .name) }}
                 {{- $name }}
-            {{- end }}
-       {{- end }}
+      {{- end }}
     {{- end }}
+  {{- end }}
 {{- end -}}
 
 {{/* Check if the priority class should be build */}}
 {{- define "imgproxy.resources.explicitPriorityClassName" }}
-    {{- with .Values.resources.deployment.priority }}
-        {{- $systemNames := list "set-cluster-critical" "set-node-critical" }}
-        {{- $name := include "imgproxy.resources.priorityClassName" $ }}
-        {{- if ($name | and (not (has $name $systemNames)) | and .level) }}
+  {{- with .Values.resources.deployment.priority }}
+    {{- $systemNames := list "set-cluster-critical" "set-node-critical" }}
+    {{- $name := include "imgproxy.resources.priorityClassName" $ }}
+    {{- if ($name | and (not (has $name $systemNames)) | and .level) }}
             {{- $name }}
-        {{- end }}
     {{- end }}
+  {{- end }}
 {{- end -}}
 
 {{/* Return name for persistent volume claim */}}
 {{- define "imgproxy.pvcName" -}}
-{{- with $.Values.persistence -}}
+  {{- with $.Values.persistence -}}
 {{- .existingClaim | default .name | print }}
-{{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* Builds the resources claim for the deployment */}}
 {{- define "imgproxy.podResources" -}}
 
-{{- $default := dict -}}
-{{- with $.Values.resources.deployment.replicas | default dict -}}
-{{- $minCount := .minCount | default 1 | int }}
-{{- $maxCount := .maxCount | default $minCount | int }}
-{{- if gt $maxCount $minCount -}}
-{{- $default = dict "requests" (dict "cpu" 1) "limits" (dict "cpu" 1) -}}
-{{- end -}}
-{{- end -}}
+  {{- $default := dict -}}
+  {{- with $.Values.resources.deployment.replicas | default dict -}}
+    {{- $minCount := .minCount | default 1 | int }}
+    {{- $maxCount := .maxCount | default $minCount | int }}
+    {{- if gt $maxCount $minCount -}}
+      {{- $default = dict "requests" (dict "cpu" 1) "limits" (dict "cpu" 1) -}}
+    {{- end -}}
+  {{- end -}}
 
-{{- $custom := $.Values.resources.deployment.resources | default dict -}}
+  {{- $custom := $.Values.resources.deployment.resources | default dict -}}
 {{- mergeOverwrite $default $custom | toYaml -}}
 {{- end -}}
 
 {{/* Combine ingress path from server.pathPrefix and ingress.pathSuffix */}}
 {{- define "imgproxy.ingressPath" -}}
-{{- $prefix := ($.Values.env.IMGPROXY_PATH_PREFIX | default "" | trimSuffix "/") -}}
-{{- $suffix := ($.Values.resources.ingress.pathSuffix | default "" | trimPrefix "/") -}}
-{{- printf "%s/%s" $prefix $suffix -}}
+  {{- $prefix := ($.Values.env.IMGPROXY_PATH_PREFIX | default "" | trimSuffix "/") -}}
+  {{- $suffix := ($.Values.resources.ingress.pathSuffix | default "" | trimPrefix "/") -}}
+  {{- printf "%s/%s" $prefix $suffix -}}
 {{- end -}}
 
 {{/* deprecated securityContext */}}
 {{- define "imgproxy.podSecurityContext" -}}
-{{- $securityContext := $.Values.resources.deployment.securityContext -}}
-{{- $podSecurityContext := $.Values.resources.deployment.podSecurityContext -}}
-{{- if and $securityContext $podSecurityContext -}}
-{{- fail "Both resources.deployment.securityContext and resources.deployment.podSecurityContext are defined. Please use only podSecurityContext." -}}
-{{- end -}}
-{{- if $securityContext -}}
-{{- printf "\n# WARNING: resources.deployment.securityContext is deprecated, please use resources.deployment.podSecurityContext instead" -}}
+  {{- $securityContext := $.Values.resources.deployment.securityContext -}}
+  {{- $podSecurityContext := $.Values.resources.deployment.podSecurityContext -}}
+  {{- if and $securityContext $podSecurityContext -}}
+    {{- fail "Both resources.deployment.securityContext and resources.deployment.podSecurityContext are defined. Please use only podSecurityContext." -}}
+  {{- end -}}
+  {{- if $securityContext -}}
+    {{- printf "\n# WARNING: resources.deployment.securityContext is deprecated, please use resources.deployment.podSecurityContext instead" -}}
 {{ $securityContext | toYaml | nindent 8 }}
-{{- else if $podSecurityContext -}}
+  {{- else if $podSecurityContext -}}
 {{ $podSecurityContext | toYaml | nindent 8 }}
-{{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/imgproxy/templates/_versions.tpl
+++ b/charts/imgproxy/templates/_versions.tpl
@@ -3,62 +3,62 @@
 
 {{/* API version of Ingress. */}}
 {{- define "imgproxy.versions.ingress" -}}
-    {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
-    {{- $apiVersions := $.Capabilities.APIVersions }}
+  {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
+  {{- $apiVersions := $.Capabilities.APIVersions }}
 
-    {{- if ($kubeVersion | semverCompare ">=1.22.0-0") -}}
-        {{- if $apiVersions.Has "networking.k8s.io/v1" -}}
+  {{- if ($kubeVersion | semverCompare ">=1.22.0-0") -}}
+    {{- if $apiVersions.Has "networking.k8s.io/v1" -}}
             {{- "networking.k8s.io/v1" -}}
-        {{- end -}}
-    {{- else if ($kubeVersion | semverCompare ">=1.19.0-0" | and ($apiVersions.Has "networking.k8s.io/v1")) -}}
-        {{- "networking.k8s.io/v1" -}}
-    {{- else if ($kubeVersion | semverCompare ">=1.14.0-0" | and ($apiVersions.Has "networking.k8s.io/v1beta1")) -}}
-        {{- "networking.k8s.io/v1beta1" -}}
-    {{- else if $apiVersions.Has "extensions/v1beta1" -}}
-        {{- "extensions/v1beta1" -}}
     {{- end -}}
+  {{- else if ($kubeVersion | semverCompare ">=1.19.0-0" | and ($apiVersions.Has "networking.k8s.io/v1")) -}}
+        {{- "networking.k8s.io/v1" -}}
+  {{- else if ($kubeVersion | semverCompare ">=1.14.0-0" | and ($apiVersions.Has "networking.k8s.io/v1beta1")) -}}
+        {{- "networking.k8s.io/v1beta1" -}}
+  {{- else if $apiVersions.Has "extensions/v1beta1" -}}
+        {{- "extensions/v1beta1" -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* API version of PriorityClass. */}}
 {{- define "imgproxy.versions.priorityClass" -}}
-    {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
-    {{- $apiVersions := $.Capabilities.APIVersions }}
+  {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
+  {{- $apiVersions := $.Capabilities.APIVersions }}
 
-    {{- if ($kubeVersion | semverCompare "<1.14.0-0" | and ($apiVersions.Has "scheduling.k8s.io/v1beta1")) -}}
+  {{- if ($kubeVersion | semverCompare "<1.14.0-0" | and ($apiVersions.Has "scheduling.k8s.io/v1beta1")) -}}
         {{- "scheduling.k8s.io/v1beta1" -}}
-    {{- else if $apiVersions.Has "scheduling.k8s.io/v1" }}
+  {{- else if $apiVersions.Has "scheduling.k8s.io/v1" }}
         {{- "scheduling.k8s.io/v1" -}}
-    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* API version of HorizontalPodAutoscaler. */}}
 {{- define "imgproxy.versions.horizontalPodAutoscaler" -}}
-    {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
-    {{- $apiVersions := $.Capabilities.APIVersions }}
+  {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
+  {{- $apiVersions := $.Capabilities.APIVersions }}
 
-    {{- if $kubeVersion | semverCompare ">=1.23.0-0" -}}
+  {{- if $kubeVersion | semverCompare ">=1.23.0-0" -}}
         {{- "autoscaling/v2" -}}
-    {{- else if $kubeVersion | semverCompare ">=1.19.0-0" | and ($apiVersions.Has "autoscaling/v2") -}}
+  {{- else if $kubeVersion | semverCompare ">=1.19.0-0" | and ($apiVersions.Has "autoscaling/v2") -}}
         {{- "autoscaling/v2" -}}
-    {{- else if $kubeVersion | semverCompare ">=1.12.0-0" | and ($apiVersions.Has "autoscaling/v2beta2") -}}
+  {{- else if $kubeVersion | semverCompare ">=1.12.0-0" | and ($apiVersions.Has "autoscaling/v2beta2") -}}
         {{- "autoscaling/v2beta2" -}}
-    {{- else if $apiVersions.Has "autoscaling/v2beta1" }}
+  {{- else if $apiVersions.Has "autoscaling/v2beta1" }}
         {{- "autoscaling/v2beta1" -}}
-    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* API version of pod disrutption budget */}}
 {{- define "imgproxy.versions.podDisruptionBudget" }}
-    {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
-    {{- $apiVersions := $.Capabilities.APIVersions }}
+  {{- $kubeVersion := $.Capabilities.KubeVersion.Version }}
+  {{- $apiVersions := $.Capabilities.APIVersions }}
 
-    {{- if $kubeVersion | semverCompare ">=1.21.0-0" -}}
+  {{- if $kubeVersion | semverCompare ">=1.21.0-0" -}}
         {{- "policy/v1" -}}
-    {{- else if $apiVersions.Has "policy/v1" }}
+  {{- else if $apiVersions.Has "policy/v1" }}
         {{- "policy/v1" -}}
-    {{- else if $apiVersions.Has "policy/v1beta1" }}
+  {{- else if $apiVersions.Has "policy/v1beta1" }}
         {{- "policy/v1beta1" -}}
-    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* Check if preemption policy is supported for PriorityClass. */}}

--- a/charts/imgproxy/templates/deployment.yaml
+++ b/charts/imgproxy/templates/deployment.yaml
@@ -16,85 +16,85 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "imgproxy.chart" $ }}
     app: {{ template "imgproxy.fullname" $ }}
-    {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
+{{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+{{- end }}
   annotations: {{ .Values.resources.deployment.annotations | toYaml | nindent 4 }}
 spec:
-  {{- if (eq $minCount $maxCount) }}
+{{- if (eq $minCount $maxCount) }}
   replicas: {{ $replicaCount | default 1 | int }}
-  {{- end }}
-  {{- if .Values.resources.deployment.minReadySeconds }}
+{{- end }}
+{{- if .Values.resources.deployment.minReadySeconds }}
   minReadySeconds: {{ .Values.resources.deployment.minReadySeconds }}
-  {{- end }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "imgproxy.fullname" $ }}
   strategy: {{ toYaml .Values.resources.deployment.strategy | nindent 4 }}
   template:
     metadata:
-      {{- with .Values.resources.pod }}
+{{- with .Values.resources.pod }}
       labels:
         app: {{ template "imgproxy.fullname" $ }}
         imgproxy: "true"
         release: {{ $.Release.Name | quote }}
-        {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
+  {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
-        {{- range $key, $val := (.labels | default dict) }}
+  {{- end }}
+  {{- range $key, $val := (.labels | default dict) }}
         {{ $key }}: {{ $val | quote }}
-        {{- end }}
+  {{- end }}
       annotations:
         checksum/env: {{ $checksumEnv }}
-        {{- if .annotations }}
+  {{- if .annotations }}
         {{- .annotations | toYaml | nindent 8 }}
-        {{- end }}
-      {{- end }}
+  {{- end }}
+{{- end }}
     spec:
       automountServiceAccountToken: {{ .Values.resources.deployment.autoMountServiceAccountToken }}
       affinity: {{ .Values.resources.deployment.affinity | toYaml | nindent 8 }}
       tolerations: {{ .Values.resources.deployment.tolerations | toYaml | nindent 8 }}
       nodeSelector: {{ .Values.resources.deployment.nodeSelector | toYaml | nindent 8 }}
-      {{- if or .Values.image.pullSecrets.enabled .Values.image.addPullSecrets }}
+{{- if or .Values.image.pullSecrets.enabled .Values.image.addPullSecrets }}
       imagePullSecrets:
-        {{- if .Values.image.pullSecrets.enabled}}
+  {{- if .Values.image.pullSecrets.enabled}}
         - name: "{{ .Release.Name }}-docker-registry-secret"
-        {{- end }}
-        {{- if .Values.image.addPullSecrets}}
-        {{- range $secretName := .Values.image.addPullSecrets }}
+  {{- end }}
+  {{- if .Values.image.addPullSecrets}}
+    {{- range $secretName := .Values.image.addPullSecrets }}
         - name: {{ $secretName | quote }}
-        {{- end }}
-        {{- end }}
-      {{- end }}
-      {{- with (include "imgproxy.podSecurityContext" .) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- with (include "imgproxy.podSecurityContext" .) }}
       securityContext:
         {{ . }}
-      {{- end }}
-      {{- if $.Values.resources.serviceAccount.existingName }}
+{{- end }}
+{{- if $.Values.resources.serviceAccount.existingName }}
       serviceAccountName: {{ $.Values.resources.serviceAccount.existingName | quote }}
-      {{- else if (include "serviceAccount.enabled" $ | eq "true") }}
+{{- else if (include "serviceAccount.enabled" $ | eq "true") }}
       serviceAccountName: "{{ template "imgproxy.fullname" $ }}-service-account"
-      {{- end }}
-      {{- if .Values.persistence.enabled }}
+{{- end }}
+{{- if .Values.persistence.enabled }}
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "imgproxy.pvcName" . }}
-      {{- end }}
-      {{- with .Values.resources.deployment.topologySpreadConstraints }}
+{{- end }}
+{{- with .Values.resources.deployment.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- range $constraint := . }}
+  {{- range $constraint := . }}
         - {{ toYaml $constraint | nindent 10 | trim }}
-        {{- if not $constraint.labelSelector }}
+    {{- if not $constraint.labelSelector }}
           labelSelector:
             matchLabels:
               app: {{ template "imgproxy.fullname" $ }}
-        {{- end }}
-        {{- end }}
-      {{- end }}
-      {{- if .Values.resources.deployment.terminationGracePeriodSeconds }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .Values.resources.deployment.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.resources.deployment.terminationGracePeriodSeconds }}
-      {{- end }}
+{{- end }}
       containers:
         - name: "imgproxy"
           image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
@@ -102,66 +102,66 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ template "imgproxy.fullname" $ }}-env-secrets
-            {{- range $secretName := .Values.resources.addSecrets }}
+{{- range $secretName := .Values.resources.addSecrets }}
             - secretRef:
                 name: {{ $secretName }}
-            {{- end }}
+{{- end }}
           resources: {{ include "imgproxy.podResources" $ | nindent 12 }}
-          {{- if .Values.persistence.enabled }}
+{{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
-              {{- if .Values.persistence.subPath }}
+  {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
-              {{- end }}
-          {{- end }}
+  {{- end }}
+{{- end }}
           ports:
             - containerPort: 8080
               name: http
               protocol: TCP
-            {{- with .Values.env.IMGPROXY_PROMETHEUS_BIND }}
+{{- with .Values.env.IMGPROXY_PROMETHEUS_BIND }}
             - containerPort: {{ mustRegexSplit ":" . -1 | mustLast | int }}
               name: metrics
               protocol: TCP
-            {{- end }}
-          {{- if .Values.resources.deployment.containerSecurityContext }}
+{{- end }}
+{{- if .Values.resources.deployment.containerSecurityContext }}
           securityContext: {{ $.Values.resources.deployment.containerSecurityContext | toYaml | nindent 12 }}
-          {{- end }}
+{{- end }}
           readinessProbe:
             httpGet:
               path: {{ .Values.env.IMGPROXY_PATH_PREFIX }}/health
               port: 8080
               scheme: HTTP
-              {{- if .Values.env.IMGPROXY_SECRET }}
+{{- if .Values.env.IMGPROXY_SECRET }}
               httpHeaders:
               - name: Authorization
                 value: Bearer {{ .Values.env.IMGPROXY_SECRET }}
-              {{- end }}
-            {{- with .Values.resources.deployment.readinessProbe }}
+{{- end }}
+{{- with .Values.resources.deployment.readinessProbe }}
             initialDelaySeconds: {{ .initialDelaySeconds | default 10 }}
             timeoutSeconds: {{ .timeoutSeconds | default 5 }}
             successThreshold: {{ .successThreshold | default 1 }}
             failureThreshold: {{ .failureThreshold | default 5 }}
-            {{- end }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.env.IMGPROXY_PATH_PREFIX }}/health
               port: 8080
               scheme: HTTP
-              {{- if .Values.env.IMGPROXY_SECRET }}
+{{- if .Values.env.IMGPROXY_SECRET }}
               httpHeaders:
                 - name: Authorization
                   value: Bearer {{ .Values.env.IMGPROXY_SECRET }}
-              {{- end }}
-            {{- with .Values.resources.deployment.livenessProbe }}
+{{- end }}
+{{- with .Values.resources.deployment.livenessProbe }}
             initialDelaySeconds: {{ .initialDelaySeconds | default 50 }}
             timeoutSeconds: {{ .timeoutSeconds | default 5 }}
             successThreshold: {{ .successThreshold | default 1 }}
             failureThreshold: {{ .failureThreshold | default 5 }}
-            {{- end }}
-          {{- with .Values.resources.deployment.lifecycle }}
+{{- end }}
+{{- with .Values.resources.deployment.lifecycle }}
           lifecycle: {{ toYaml . | nindent 12 }}
-          {{- end }}
-      {{- if ($priorityClassName | and $priorityClassVersion) }}
+{{- end }}
+{{- if ($priorityClassName | and $priorityClassVersion) }}
       priorityClassName: {{ $priorityClassName | quote }}
-      {{- end }}
+{{- end }}

--- a/charts/imgproxy/templates/env-secret.yaml
+++ b/charts/imgproxy/templates/env-secret.yaml
@@ -8,13 +8,13 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     imgproxy: "true"
-    {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
+{{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+{{- end }}
 type: kubernetes.io/Opaque
 data:
-  {{- range $key, $val := .Values.env }}
+{{- range $key, $val := .Values.env }}
   {{- if $val }}
   {{ $key }}: {{ $val | toString | b64enc | quote }} # {{ $val }}
   {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/imgproxy/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/imgproxy/templates/horizontal-pod-autoscaler.yaml
@@ -1,8 +1,8 @@
 {{- $apiVersion := include "imgproxy.versions.horizontalPodAutoscaler" $ }}
 {{- with .Values.resources.deployment.replicas | default dict -}}
-{{- $minCount := .minCount | default 1 | int }}
-{{- $maxCount := .maxCount | default $minCount | int }}
-{{- if gt $maxCount $minCount -}}
+  {{- $minCount := .minCount | default 1 | int }}
+  {{- $maxCount := .maxCount | default $minCount | int }}
+  {{- if gt $maxCount $minCount -}}
 ---
 apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
@@ -25,25 +25,25 @@ spec:
     apiVersion: apps/v1
   behavior:
     scaleDown:
-      {{- $scaleDown := .scaleDownBehavior | default dict }}
+    {{- $scaleDown := .scaleDownBehavior | default dict }}
       policies:
         - type: Pods
           value: {{ $scaleDown.stepCount | default .stepCount | default 1 | max 1 }}
           periodSeconds: {{ $scaleDown.stepSeconds | default .stepSeconds | default 60 | max 1 | min 1800 }}
       stabilizationWindowSeconds: {{ $scaleDown.stabilizationInterval | default .stabilizationInterval | default 300 | max 0 | min 3600 }}
-      {{- if $scaleDown.selectPolicy }}
+    {{- if $scaleDown.selectPolicy }}
       selectPolicy: {{ $scaleDown.selectPolicy }}
-      {{- end }}
+    {{- end }}
     scaleUp:
-      {{- $scaleUp := .scaleUpBehavior | default dict }}
+    {{- $scaleUp := .scaleUpBehavior | default dict }}
       policies:
         - type: Pods
           value: {{ $scaleUp.stepCount | default .stepCount | default 1 | max 1 }}
           periodSeconds: {{ $scaleUp.stepSeconds | default .stepSeconds | default 60 | max 1 | min 1800 }}
       stabilizationWindowSeconds: {{ $scaleUp.stabilizationInterval | default .stabilizationInterval | default 300 | max 0 | min 3600 }}
-      {{- if $scaleUp.selectPolicy }}
+    {{- if $scaleUp.selectPolicy }}
       selectPolicy: {{ $scaleUp.selectPolicy }}
-      {{- end }}
+    {{- end }}
   metrics:
     - type: Resource
       resource:
@@ -51,5 +51,5 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .cpuUtilization | default 80 }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/imgproxy/templates/image-pull-secret.yaml
+++ b/charts/imgproxy/templates/image-pull-secret.yaml
@@ -10,9 +10,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
     imgproxy: "true"
-    {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
+  {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
   name: "{{ .Release.Name }}-docker-registry-secret"
 type: kubernetes.io/dockerconfigjson
 {{- end }}

--- a/charts/imgproxy/templates/ingress-health.yaml
+++ b/charts/imgproxy/templates/ingress-health.yaml
@@ -1,6 +1,6 @@
 {{- $apiVersion := include "imgproxy.versions.ingress" . }}
 {{- with .Values.resources.ingress }}
-{{- if (.enabled | and $apiVersion | and .health.whitelist) }}
+  {{- if (.enabled | and $apiVersion | and .health.whitelist) }}
 ---
 apiVersion: {{ $apiVersion }}
 kind: Ingress
@@ -21,27 +21,27 @@ metadata:
     {{- toYaml .annotations | nindent 4 }}
     {{- end }}
 spec:
-  {{- if .className }}
+    {{- if .className }}
   ingressClassName: {{ .className | quote }}
-  {{- end }}
-  {{- if .tls }}
+    {{- end }}
+    {{- if .tls }}
   tls:
-    {{- range .tls }}
+      {{- range .tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
       secretName: {{ .secretName }}
+      {{- end }}
     {{- end }}
-  {{- end }}
   rules:
     {{- range .hosts }}
     - host: {{ . | quote }}
       http:
         paths:
-          {{- $name := include "imgproxy.fullname" $ }}
-          {{- $path := ($.Values.env.IMGPROXY_PATH_PREFIX | default "" | printf "%s/health") }}
-          {{- if eq $apiVersion "networking.k8s.io/v1" }}
+      {{- $name := include "imgproxy.fullname" $ }}
+      {{- $path := ($.Values.env.IMGPROXY_PATH_PREFIX | default "" | printf "%s/health") }}
+      {{- if eq $apiVersion "networking.k8s.io/v1" }}
           - path: {{ $path | quote }}
             pathType: Exact
             backend:
@@ -49,12 +49,12 @@ spec:
                 name: {{ $name | quote }}
                 port:
                   number: 80
-          {{- else }}
+      {{- else }}
           - path: {{ $path | quote }}
             backend:
               serviceName: {{ $name | quote }}
               servicePort: 80
-          {{- end }}
-{{- end }}
-{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/imgproxy/templates/ingress.yaml
+++ b/charts/imgproxy/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $apiVersion := include "imgproxy.versions.ingress" . }}
 {{- with .Values.resources.ingress }}
-{{- if (.enabled | and $apiVersion) }}
+  {{- if (.enabled | and $apiVersion) }}
 ---
 apiVersion: {{ $apiVersion }}
 kind: Ingress
@@ -15,38 +15,38 @@ metadata:
     {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
-  {{- with .annotations }}
+    {{- with .annotations }}
   annotations:
-    {{- $tp := typeOf . }}
-    {{- if eq $tp "string" }}
+      {{- $tp := typeOf . }}
+      {{- if eq $tp "string" }}
       {{- tpl . $ | nindent 4 }}
-    {{- else }}
+      {{- else }}
       {{- toYaml . | nindent 4 }}
+      {{- end }}
     {{- end }}
-  {{- end }}
 spec:
-  {{- if .className }}
+    {{- if .className }}
   ingressClassName: {{ .className | quote }}
-  {{- end }}
-  {{- if .tls }}
+    {{- end }}
+    {{- if .tls }}
   tls:
-    {{- range .tls }}
+      {{- range .tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
       secretName: {{ .secretName }}
+      {{- end }}
     {{- end }}
-  {{- end }}
-  {{- $pathType := .pathType | default "ImplementationSpecific" }}
+    {{- $pathType := .pathType | default "ImplementationSpecific" }}
   rules:
     {{- range .hosts }}
     - host: {{ . | quote }}
       http:
         paths:
-          {{- $name := include "imgproxy.fullname" $ }}
-          {{- $path := include "imgproxy.ingressPath" $ }}
-          {{- if eq $apiVersion "networking.k8s.io/v1" }}
+      {{- $name := include "imgproxy.fullname" $ }}
+      {{- $path := include "imgproxy.ingressPath" $ }}
+      {{- if eq $apiVersion "networking.k8s.io/v1" }}
           - path: {{ $path | quote }}
             pathType: {{ $pathType | quote }}
             backend:
@@ -54,12 +54,12 @@ spec:
                 name: {{ $name | quote }}
                 port:
                   number: 80
-          {{- else }}
+      {{- else }}
           - path: {{ $path | quote }}
             backend:
               serviceName: {{ $name | quote }}
               servicePort: 80
-          {{- end }}
-{{- end }}
-{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/imgproxy/templates/pod-disruption-budget.yaml
+++ b/charts/imgproxy/templates/pod-disruption-budget.yaml
@@ -1,6 +1,6 @@
 {{- $apiVersion := include "imgproxy.versions.podDisruptionBudget" . }}
 {{- with .Values.resources.podDisruptionBudget -}}
-{{- if (.enabled | and $apiVersion) }}
+  {{- if (.enabled | and $apiVersion) }}
 ---
 apiVersion: {{ $apiVersion }}
 kind: PodDisruptionBudget
@@ -12,14 +12,14 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end }}
 spec:
-  {{- if .minAvailable }}
+    {{- if .minAvailable }}
   minAvailable: {{ .minAvailable }}
-  {{- end }}
-  {{- if .maxUnavailable }}
+    {{- end }}
+    {{- if .maxUnavailable }}
   maxUnavailable: {{ .maxUnavailable }}
-  {{- end }}
+    {{- end }}
   selector:
     matchLabels:
       app: {{ template "imgproxy.fullname" $ }}
-{{- end -}}
+  {{- end -}}
 {{- end }}

--- a/charts/imgproxy/templates/priority-class.yaml
+++ b/charts/imgproxy/templates/priority-class.yaml
@@ -1,7 +1,7 @@
 {{- $preemptionPolicyFeature := include "imgproxy.versions.features.priorityClassPreemptionPolicy" $ -}}
 {{- $name := include "imgproxy.resources.explicitPriorityClassName" $ -}}
 {{- if $name -}}
-{{- with .Values.resources.deployment.priority -}}
+  {{- with .Values.resources.deployment.priority -}}
 ---
 apiVersion: {{ include "imgproxy.versions.priorityClass" $ | quote }}
 kind: PriorityClass
@@ -15,8 +15,8 @@ metadata:
 value: {{ (.level | max 0 | min 1000000000) }}
 globalDefault: false
 description: "This priority class should be used for '{{ template "imgproxy.fullname" $ }}' pods only."
-{{- if (not .preempting | and $preemptionPolicyFeature) }}
+    {{- if (not .preempting | and $preemptionPolicyFeature) }}
 preemptionPolicy: Never
-{{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/imgproxy/templates/service-account.yaml
+++ b/charts/imgproxy/templates/service-account.yaml
@@ -5,16 +5,16 @@ metadata:
   name: {{ template "imgproxy.fullname" $ }}-service-account
   labels:
     imgproxy: "true"
-    {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
+  {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+  {{- end }}
   annotations:
-    {{- with .Values.resources.serviceAccount }}
+  {{- with .Values.resources.serviceAccount }}
     {{- if .annotations }}
     {{- .annotations | toYaml | nindent 4 }}
     {{- end }}
     {{- if (or .aws.iamRoleName .aws.accountId) }}
     {{ include "aws.iamRoleAnnotation" $ }}
     {{- end }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/imgproxy/templates/service-monitor.yaml
+++ b/charts/imgproxy/templates/service-monitor.yaml
@@ -1,12 +1,12 @@
 {{- if and (.Values.env.IMGPROXY_PROMETHEUS_BIND) (.Values.resources.serviceMonitor.enabled) }}
-{{- with .Values.resources.serviceMonitor }}
+  {{- with .Values.resources.serviceMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "imgproxy.fullname" $  }}
-  {{- if .namespace }}
+    {{- if .namespace }}
   namespace: {{ .namespace }}
-  {{- end }}
+    {{- end }}
   labels:
     imgproxy: "true"
     {{- range $key, $val := (.selector | default dict) }}
@@ -18,9 +18,9 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      {{- if .interval }}
+    {{- if .interval }}
       interval: {{ .interval }}
-      {{- end }}
+    {{- end }}
       honorLabels: {{ .honorLabels }}
   namespaceSelector:
     matchNames:
@@ -29,11 +29,11 @@ spec:
     matchLabels:
       app: {{ $.Release.Name | quote }}
       imgproxy: "true"
-  {{- if .targetLabels }}
+    {{- if .targetLabels }}
   targetLabels:
-  {{- range $label := .targetLabels }}
+      {{- range $label := .targetLabels }}
     - {{ $label }}
-  {{- end }}
-  {{- end }}
-{{- end -}}
+      {{- end }}
+    {{- end }}
+  {{- end -}}
 {{- end -}}

--- a/charts/imgproxy/templates/service.yaml
+++ b/charts/imgproxy/templates/service.yaml
@@ -8,9 +8,9 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     imgproxy: "true"
     release: {{ .Release.Name | quote }}
-    {{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
+{{- range $key, $val := ($.Values.resources.common.labels | default dict) }}
     {{ $key }}: {{ $val | quote }}
-    {{- end }}
+{{- end }}
 {{- with .Values.resources.service }}
   {{- if .annotations }}
   annotations: {{ .annotations | toYaml | nindent 4 }}
@@ -19,16 +19,16 @@ spec:
   type: {{ .type | default "ClusterIP" | quote }}
   {{- if eq .type "LoadBalancer" }}
   loadBalancerIP: {{ .loadBalancerIP | default "" | quote }}
-  {{- if .loadBalancerSourceRanges }}
+    {{- if .loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ .loadBalancerSourceRanges | toYaml | nindent 4 }}
-  {{- end }}
-  {{- if .externalTrafficPolicy }}
+    {{- end }}
+    {{- if .externalTrafficPolicy }}
   externalTrafficPolicy: {{ .externalTrafficPolicy | quote }}
-  {{- end }}
+    {{- end }}
   {{- else if eq .type "NodePort" }}
-  {{- if .externalTrafficPolicy }}
+    {{- if .externalTrafficPolicy }}
   externalTrafficPolicy: {{ .externalTrafficPolicy | quote }}
-  {{- end }}
+    {{- end }}
   {{- end }}
   selector:
     app: "{{ template "imgproxy.fullname" $ }}"
@@ -37,15 +37,15 @@ spec:
       port: {{ .port | default 80 }}
       protocol: TCP
       targetPort: 8080
-      {{- if eq .type "NodePort" }}
+  {{- if eq .type "NodePort" }}
       nodePort: {{ .nodePort | default "" }}
-      {{- end }}
-    {{- with $.Values.env }}
+  {{- end }}
+  {{- with $.Values.env }}
     {{- if .IMGPROXY_PROMETHEUS_BIND }}
     - name: metrics
       port: {{ mustRegexSplit ":" .IMGPROXY_PROMETHEUS_BIND -1 | mustLast | int }}
       protocol: TCP
       targetPort: {{ mustRegexSplit ":" .IMGPROXY_PROMETHEUS_BIND -1 | mustLast | int }}
     {{- end }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,4 @@
 module.exports = {
     "*": () => "npx prettier -c .",
+    "charts/**/*.{tpl,yml,yaml}": "helmfmt --check --files",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,16 +18,16 @@
             }
         },
         "charts/comet-admin-v1": {
-            "version": "1.8.0"
+            "version": "1.8.1"
         },
         "charts/comet-api-v1": {
-            "version": "1.15.0"
+            "version": "1.18.0"
         },
         "charts/comet-api-v2": {
-            "version": "1.15.0"
+            "version": "2.4.0"
         },
         "charts/comet-ingress-v1": {
-            "version": "1.0.1"
+            "version": "1.2.0"
         },
         "charts/comet-keda-v1": {
             "version": "1.1.0"
@@ -36,10 +36,10 @@
             "version": "1.2.0"
         },
         "charts/comet-site-v1": {
-            "version": "1.11.0"
+            "version": "1.13.0"
         },
         "charts/imgproxy": {
-            "version": "0.10.2"
+            "version": "1.0.0"
         },
         "node_modules/@babel/runtime": {
             "version": "7.26.0",


### PR DESCRIPTION
## Summary
- Integrates [helmfmt](https://github.com/digitalstudium/helmfmt) to enforce consistent formatting across all Helm chart templates
- Adds `.helmfmt` config and a `helmfmt --check` step in the `Lint and Prettier Check` workflow (pinned to `v0.5.0`)
- Adds a lint-staged entry for `charts/**/*.{tpl,yml,yaml}` so changed templates are checked pre-commit
- Reformats all existing templates so the new CI check passes

## Test plan
- [x] CI `Lint and Prettier Check` job is green
- [x] `helmfmt --check charts/<chart>/` passes locally for every chart
- [x] `helm template` output for each chart is unchanged vs. main (formatting-only changes)

## Notes for reviewers / contributors
Install helmfmt locally to make the pre-commit hook work:
```
curl -L https://github.com/digitalstudium/helmfmt/releases/download/v0.5.0/helmfmt_Darwin_arm64.tar.gz \
  | sudo tar -xzf - -C /usr/local/bin/ helmfmt
```
(Linux: use the `helmfmt_Linux_x86_64.tar.gz` asset.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)