### PR TITLE
feat: Switch probes to dedicated /healthcheck/* endpoints

### DIFF
--- a/.changeset/gold-hats-grow.md
+++ b/.changeset/gold-hats-grow.md
@@ -1,0 +1,15 @@
+---
+"comet-site-preview-v2": major
+"comet-admin-v2": major
+"comet-site-v2": major
+"comet-api-v3": major
+---
+
+Switch all probes to dedicated `/healthcheck/*` endpoints to reduce noise from health-check requests in monitoring tools (e.g. Sentry false positives that can't be filtered via inbound filters).
+
+-   `comet-admin-v2`: `/status/health` → `livenessProbe: /healthcheck/live`, `readinessProbe: /healthcheck/ready`
+-   `comet-api-v3`: `/api/status/{liveness,readiness}` → `livenessProbe: /api/healthcheck/live`, `readinessProbe: /healthcheck/ready`, `startupProbe: /api/healthcheck/ready`
+-   `comet-site-v2`: `/api/status` → `livenessProbe: /healthcheck/live`, `readinessProbe: /healthcheck/ready`; prelogin `/login/api/status` → `/login/healthcheck/{live,ready}`
+-   `comet-site-preview-v2`: `/site/api/status` → `livenessProbe: /site/healthcheck/live`, `readinessProbe: /site/healthcheck/ready`
+
+**Breaking change:** the underlying applications must expose the new endpoints before upgrading, otherwise pods will fail their probes and won't become ready.

--- a/charts/comet-admin-v2/.helmignore
+++ b/charts/comet-admin-v2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/comet-admin-v2/CHANGELOG.md
+++ b/charts/comet-admin-v2/CHANGELOG.md
@@ -1,0 +1,77 @@
+# comet-admin-v1
+
+## 1.8.1
+
+### Patch Changes
+
+-   fa9549a: Checksum for Secret was not rendered when `podAnnotations` was empty, preventing automatic pod restarts on config changes. Replaced `{{- with .Values.podAnnotations }}` wrapper with direct `{{- range }}` iteration to ensure checksums are always present regardless of user-defined annotations.
+
+## 1.8.0
+
+### Minor Changes
+
+-   7fc3076: Allow custom annotations for route
+
+## 1.7.0
+
+### Minor Changes
+
+-   1c2fca7: Allow to disable tls for routes
+
+## 1.6.0
+
+### Minor Changes
+
+-   d337b44: Increase CPU limit from 1 to 2
+
+## 1.5.0
+
+### Minor Changes
+
+-   e0fc0ee: Add configuration to expose metrics port for services
+
+## 1.4.0
+
+### Minor Changes
+
+-   41235fb: feat: add checksum annotations for auto-rollout on ConfigMap and Secret updates in Deployment templates
+
+## 1.3.0
+
+### Minor Changes
+
+-   Add configuration to expose metrics port
+
+## 1.2.0
+
+### Minor Changes
+
+-   Split selectorLabels into selectorLabels and selectorMatchLabels in comet-admin, comet-api and comet-site templates to modify pod labels without using additionalPodLabels parameter and without changing the matchLabels section
+
+## 1.1.0
+
+### Minor Changes
+
+-   190295a: Add app label to api and admin charts to match the existing label configuration
+
+## 1.0.0
+
+### Major Changes
+
+-   0dd1ebb: - BREAKING: Deactivate `autoMountServiceAccountToken` by default
+
+### Minor Changes
+
+-   0dd1ebb: - Don't generate/use image-pull-secrets if none are set
+    -   Add support for both tag and hash for images. Hash will be used if no tag is set
+    -   Add possibility to add annotations to ingress (e.g. in use by NGINX Ingress Controller)
+    -   Remove default env-variables as they should be set explicitly
+    -   Remove cdn-configuration as it made things more complicated than necessary
+    -   Add option to add labels to pods
+
+### Patch Changes
+
+-   0dd1ebb: - Add option to disable `automountServiceAccountToken`
+    -   Replace template information in `Chart.yaml` with correct information
+    -   Fix syntax: Templates resulted in a syntax error when `image.pullSecret` is set.
+    -   Change `additionalLabels` variable to `additionalPodLabels` for better understanding

--- a/charts/comet-admin-v2/Chart.yaml
+++ b/charts/comet-admin-v2/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: comet-admin
+description: Helm chart for a Comet Admin Microservice
+type: application
+
+home: https://www.comet-dxp.com
+icon: https://avatars.githubusercontent.com/u/1012348?s=200&v=4
+
+maintainers:
+  - name: Daniel Karnutsch
+    email: daniel.karnutsch@vivid-planet.com
+  - name: Georg Schreglmann
+    email: georg.schreglmann@vivid-planet.com
+  - name: Franz Unger
+    email: franz.unger@vivid-planet.com
+  - name: Alexander Kaufmann
+    email: alexander.kaufmann@vivid-planet.com
+
+version: 1.8.1

--- a/charts/comet-admin-v2/package.json
+++ b/charts/comet-admin-v2/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "comet-admin-v2",
+    "private": true,
+    "version": "1.8.1"
+}

--- a/charts/comet-admin-v2/templates/NOTES.txt
+++ b/charts/comet-admin-v2/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "comet-admin.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "comet-admin.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "comet-admin.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "comet-admin.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/comet-admin-v2/templates/_helpers.tpl
+++ b/charts/comet-admin-v2/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "comet-admin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "comet-admin.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "comet-admin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "comet-admin.labels" -}}
+helm.sh/chart: {{ include "comet-admin.chart" . }}
+{{ include "comet-admin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "comet-admin.selectorLabels" -}}
+app: {{ include "comet-admin.fullname" . }}
+app.kubernetes.io/name: {{ include "comet-admin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector matchLabels
+*/}}
+{{- define "comet-admin.selectorMatchLabels" -}}
+app.kubernetes.io/name: {{ include "comet-admin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/comet-admin-v2/templates/deployment.yaml
+++ b/charts/comet-admin-v2/templates/deployment.yaml
@@ -65,11 +65,11 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /status/health
+              path: /healthcheck/live
               port: http
           readinessProbe:
             httpGet:
-              path: /status/health
+              path: /healthcheck/ready
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/comet-admin-v2/templates/deployment.yaml
+++ b/charts/comet-admin-v2/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "comet-admin.fullname" . }}
+  labels:
+    {{- include "comet-admin.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "comet-admin.selectorMatchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.image.pullSecret }}
+        checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- range $key, $val := .Values.podAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      labels:
+        {{- include "comet-admin.selectorLabels" . | nindent 8 }}
+        {{- range $key, $val := .Values.additionalPodLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ include "comet-admin.fullname" . }}-image-pull-secret
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.containerPorts.http }}
+              protocol: TCP
+            {{- end }}
+          env:
+            - name: NODE_ENV
+              value: "{{ .Values.nodeEnv }}"
+            - name: NPM_RUN
+              value: "{{ .Values.npmRun }}"
+            - name: TZ
+              value: "{{ .Values.timeZone }}"
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/comet-admin-v2/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/comet-admin-v2/templates/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "comet-admin.fullname" . }}
+  labels:
+    {{- include "comet-admin.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "comet-admin.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/comet-admin-v2/templates/image-pull-secret.yaml
+++ b/charts/comet-admin-v2/templates/image-pull-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.image.pullSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-admin.fullname" . }}-image-pull-secret
+  labels:
+    {{- include "comet-admin.labels" . | nindent 8 }}
+data:
+  .dockerconfigjson: {{ required "Missing image.pullSecret" .Values.image.pullSecret }}
+type: kubernetes.io/dockerconfigjson
+{{- end }}

--- a/charts/comet-admin-v2/templates/ingress.yaml
+++ b/charts/comet-admin-v2/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "comet-admin.fullname" . }}
+  labels:
+    {{- include "comet-admin.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $val := .Values.ingress.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: "{{ .Values.domain }}"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "comet-admin.fullname" . }}
+            port:
+              number: 3000
+  tls:
+  - hosts:
+    - "{{ .Values.domain }}"
+    secretName: {{ include "comet-admin.fullname" . }}-cert
+{{- end }}

--- a/charts/comet-admin-v2/templates/pod-disruption-budget.yaml
+++ b/charts/comet-admin-v2/templates/pod-disruption-budget.yaml
@@ -1,0 +1,13 @@
+{{- if or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1)) }}
+apiVersion: "policy/v1"
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "comet-admin.labels" . | nindent 4 }}
+  name: {{ include "comet-admin.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "comet-admin.selectorLabels" . | nindent 6 }}
+  minAvailable: 1
+{{- end }}

--- a/charts/comet-admin-v2/templates/route.yaml
+++ b/charts/comet-admin-v2/templates/route.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "comet-admin.fullname" . }}
+  labels:
+    {{- include "comet-admin.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $val := .Values.route.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  host: "{{ .Values.domain }}"
+  port:
+    targetPort: http
+  {{- if .Values.route.tls.enabled }}
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "comet-admin.fullname" . }}
+    weight: 100
+{{- end }}

--- a/charts/comet-admin-v2/templates/service.yaml
+++ b/charts/comet-admin-v2/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "comet-admin.fullname" . }}
+  labels:
+    {{- include "comet-admin.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.containerPorts.http }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "comet-admin.selectorLabels" . | nindent 4 }}

--- a/charts/comet-admin-v2/templates/tests/test-connection.yaml
+++ b/charts/comet-admin-v2/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "comet-admin.fullname" . }}-test-connection"
+  labels:
+    {{- include "comet-admin.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "comet-admin.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/comet-admin-v2/values.yaml
+++ b/charts/comet-admin-v2/values.yaml
@@ -1,0 +1,76 @@
+nodeEnv: production
+npmRun: serve
+timeZone: Europe/Vienna
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  hash: "" # will be used, if tag is not set
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecret: "" # will be overwritten by CI
+
+nameOverride: ""
+fullnameOverride: ""
+
+domain: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+autoMountServiceAccountToken: false
+
+service:
+  type: ClusterIP
+  port: 3000
+
+metrics:
+  enabled: false
+  containerPorts:
+    http: 9466
+
+ingress:
+  enabled: false
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt"
+
+route:
+  enabled: false
+  tls:
+    enabled: true
+  annotations: {}
+
+resources:
+  limits:
+    cpu: 2
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+additionalPodLabels: {}

--- a/charts/comet-api-v3/.helmignore
+++ b/charts/comet-api-v3/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/comet-api-v3/CHANGELOG.md
+++ b/charts/comet-api-v3/CHANGELOG.md
@@ -1,0 +1,47 @@
+# comet-api-v2
+
+## 2.4.0
+
+### Minor Changes
+
+-   37a8fab: Make the application container port configurable via the `containerPorts.http` value (defaults to `3000`, preserving current behavior). Also switch the Ingress backend to reference the Service port by name (`http`) instead of a hardcoded `3000`, so custom `service.port` / `containerPorts.http` values work end-to-end.
+
+## 2.3.0
+
+### Minor Changes
+
+-   b3d23b7: Allow overriding the `comet-dxp.com/instance` label via `instanceNameOverride` value
+
+## 2.2.2
+
+### Patch Changes
+
+-   4b91c23: Only delete migration resources before new hook creation
+
+## 2.2.1
+
+### Patch Changes
+
+-   9aaebec: Prevent deletion of migration secrets/configmap on hook failure
+
+## 2.2.0
+
+### Minor Changes
+
+-   3e5cae4: Allow custom annotations for CronJobs
+
+### Patch Changes
+
+-   2eba5eb: Checksums for ConfigMaps and Secrets were not rendered when `podAnnotations` was empty, preventing automatic pod restarts on config changes. Replaced `{{- with .Values.podAnnotations }}` wrapper with direct `{{- range }}` iteration to ensure checksums are always present regardless of user-defined annotations.
+
+## 2.1.0
+
+### Minor Changes
+
+-   172a260: Add dedicated Secrets and ConfigMap for migration job with auto-cleanup
+
+## 2.0.0
+
+### Major Changes
+
+-   f23b2ab: **BREAKING**: Move migrations from initContainers to Helm migration hook

--- a/charts/comet-api-v3/Chart.yaml
+++ b/charts/comet-api-v3/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: comet-api
+description: Helm chart for a Comet API Microservice
+type: application
+
+home: https://www.comet-dxp.com
+icon: https://avatars.githubusercontent.com/u/1012348?s=200&v=4
+
+maintainers:
+  - name: Daniel Karnutsch
+    email: daniel.karnutsch@vivid-planet.com
+  - name: Georg Schreglmann
+    email: georg.schreglmann@vivid-planet.com
+  - name: Franz Unger
+    email: franz.unger@vivid-planet.com
+  - name: Alexander Kaufmann
+    email: alexander.kaufmann@vivid-planet.com
+
+version: 2.4.0

--- a/charts/comet-api-v3/package.json
+++ b/charts/comet-api-v3/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "comet-api-v3",
+    "private": true,
+    "version": "2.4.0"
+}

--- a/charts/comet-api-v3/templates/NOTES.txt
+++ b/charts/comet-api-v3/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "comet-api.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "comet-api.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "comet-api.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "comet-api.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/comet-api-v3/templates/_helpers.tpl
+++ b/charts/comet-api-v3/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "comet-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "comet-api.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "comet-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "comet-api.labels" -}}
+helm.sh/chart: {{ include "comet-api.chart" . }}
+{{ include "comet-api.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "comet-api.selectorLabels" -}}
+app: {{ include "comet-api.fullname" . }}
+app.kubernetes.io/name: {{ include "comet-api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector matchLabels
+*/}}
+{{- define "comet-api.selectorMatchLabels" -}}
+app.kubernetes.io/name: {{ include "comet-api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "comet-api.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "comet-api.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/comet-api-v3/templates/config-map.yaml
+++ b/charts/comet-api-v3/templates/config-map.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "comet-api.fullname" . }}
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+data:
+  HELM_RELEASE: "{{ .Release.Name }}"
+  {{- range $key, $val := .Values.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-api-v3/templates/cron-jobs.yaml
+++ b/charts/comet-api-v3/templates/cron-jobs.yaml
@@ -1,0 +1,105 @@
+{{- range $name, $job := .Values.cronJobs }}
+{{- with $ -}}
+{{- if or $job.enabled (not (hasKey $job "enabled")) }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ print (include "comet-api.fullname" .) "-" $name | trunc 52 | trimSuffix "-" }}
+  annotations:
+    {{- range $key, $val := $job.additionalAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  labels:
+    comet-dxp.com/instance: "{{ $job.instanceNameOverride | default .Release.Name }}"
+    {{- include "comet-api.labels" . | nindent 4 }}
+    {{- if $job.additionalLabels }}
+      {{- tpl ($job.additionalLabels | toYaml) . | nindent 4 }}
+    {{- end }}
+spec:
+  schedule: {{ $job.schedule | quote }}
+  suspend: {{ $job.suspend | default false }}
+  timeZone: {{ $job.timeZone | default "Europe/Vienna" }}
+  successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit | default 2 }}
+  failedJobsHistoryLimit: {{ $job.failedJobsHistoryLimit | default 2 }}
+  concurrencyPolicy: {{ $job.concurrencyPolicy | default "Forbid" }}
+  startingDeadlineSeconds: {{ $job.startingDeadlineSeconds | default 120 }}
+  jobTemplate:
+    metadata:
+      annotations:
+        comet-dxp.com/trigger: "cronjob"
+      labels:
+        comet-dxp.com/instance: "{{ $job.instanceNameOverride | default .Release.Name }}"
+        comet-dxp.com/parent-cron-job: {{ print (include "comet-api.fullname" .) "-" $name | trunc 52 | trimSuffix "-" }}
+    spec:
+      backoffLimit: {{ $job.backoffLimit | default 1 }}
+      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds | default 600 }}
+      ttlSecondsAfterFinished: {{ $job.ttlSecondsAfterFinished | default 604800 }}
+      template:
+        metadata:
+          labels:
+            {{- range $key, $val := $job.additionalPodLabels }}
+            {{ $key }}: {{ $val | quote }}
+            {{- end }}
+        spec:
+          {{- if .Values.image.pullSecret }}
+          imagePullSecrets:
+            - name: {{ include "comet-api.fullname" . }}-image-pull-secret
+          {{- end }}
+          restartPolicy: {{ $job.restartPolicy | default "Never" }}
+          serviceAccountName: {{ include "comet-api.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
+          containers:
+            - name: {{ .Chart.Name }}-cronjob-{{ $name }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              {{- if .Values.image.tag }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              {{- else }}
+              image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+              {{- end }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["bash", "-c", {{ $job.command }}]
+              {{- if $job.env }}
+              env:
+                {{- range $key, $val := $job.env }}
+                - name: {{ $key }}
+                  value: {{ $val | quote }}
+                {{- end }}
+              {{- end }}
+              envFrom:
+                {{- if .Values.env }}
+                - configMapRef:
+                    name: {{ include "comet-api.fullname" . }}
+                {{- end }}
+                {{- range $key, $val := .Values.additionalConfigMapNames }}
+                - configMapRef:
+                    name:  {{ $val }}
+                {{- end }}
+                {{- if .Values.secrets }}
+                - secretRef:
+                    name: {{ include "comet-api.fullname" . }}
+                {{- end }}
+                {{- range $key, $val := .Values.additionalSecretNames }}
+                - secretRef:
+                    name:  {{ $val }}
+                {{- end }}
+              volumeMounts:
+                {{- if .Values.serviceAccount.create }}
+                - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+                  name: service-account
+                  readOnly: true
+                {{- end }}
+              resources:
+                {{- $job.resources | default .Values.resources | toYaml | nindent 16 }}
+          volumes:
+            {{- if .Values.serviceAccount.create }}
+            - name: "service-account"
+              secret:
+                secretName: {{ include "comet-api.fullname" . }}-service-account-token
+            {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/comet-api-v3/templates/deployment.yaml
+++ b/charts/comet-api-v3/templates/deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "comet-api.fullname" . }}
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "comet-api.selectorMatchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.env }}
+        checksum/config-map: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.image.pullSecret }}
+        checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.secrets }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- range $key, $val := .Values.podAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      labels:
+        {{- include "comet-api.selectorLabels" . | nindent 8 }}
+        {{- range $key, $val := .Values.additionalPodLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ include "comet-api.fullname" . }}-image-pull-secret
+      {{- end }}
+      serviceAccountName: {{ include "comet-api.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPorts.http }}
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.containerPorts.http }}
+              protocol: TCP
+            {{- end }}
+          envFrom:
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ include "comet-api.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalConfigMapNames }}
+            - configMapRef:
+                name:  {{ $val }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "comet-api.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalSecretNames }}
+            - secretRef:
+                name:  {{ $val }}
+            {{- end }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            {{- if .Values.serviceAccount.create }}
+            - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+              name: service-account
+              readOnly: true
+            {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: "1Gi"
+        {{- if .Values.serviceAccount.create }}
+        - name: "service-account"
+          secret:
+            secretName: {{ include "comet-api.fullname" . }}-service-account-token
+        {{- end }}

--- a/charts/comet-api-v3/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/comet-api-v3/templates/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "comet-api.fullname" . }}
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "comet-api.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/comet-api-v3/templates/image-pull-secret.yaml
+++ b/charts/comet-api-v3/templates/image-pull-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.image.pullSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-api.fullname" . }}-image-pull-secret
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+data:
+  .dockerconfigjson: {{ required "Missing image.pullSecret" .Values.image.pullSecret }}
+type: kubernetes.io/dockerconfigjson
+{{- end }}

--- a/charts/comet-api-v3/templates/ingress.yaml
+++ b/charts/comet-api-v3/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "comet-api.fullname" . }}
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $val := .Values.ingress.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ .Values.domain }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "comet-api.fullname" . }}
+            port:
+              name: http
+  tls:
+  - hosts:
+    - {{ .Values.domain }}
+    secretName: {{ include "comet-api.fullname" . }}-cert
+{{- end }}

--- a/charts/comet-api-v3/templates/migrations-job.yaml
+++ b/charts/comet-api-v3/templates/migrations-job.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.migration.enabled }}
+{{- if .Values.image.pullSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-api.fullname" . }}-migrations-image-pull-secret
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade # Execute this hook before install and upgrade so migrations can authenticate to the registry
+    "helm.sh/hook-weight": "-3" # Ensure this hook runs first by giving it a high priority (lower weight runs earlier)
+    "helm.sh/hook-delete-policy": before-hook-creation # Remove the secret before hook creation
+data:
+  .dockerconfigjson: {{ required "Missing image.pullSecret" .Values.image.pullSecret }}
+type: kubernetes.io/dockerconfigjson
+{{- end }}
+---
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-api.fullname" . }}-migrations
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade # Execute this hook before install and upgrade so migrations can access the secrets
+    "helm.sh/hook-weight": "-2" # Ensure this hook runs first by giving it a high priority (lower weight runs earlier)
+    "helm.sh/hook-delete-policy": before-hook-creation # Remove the secret before hook creation
+type: Opaque
+stringData:
+  {{- range $key, $val := .Values.secrets }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "comet-api.fullname" . }}-migrations
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade # Execute this hook before install and upgrade so migrations can access the configmap
+    "helm.sh/hook-weight": "-1" # Ensure this hook runs first by giving it a high priority (lower weight runs earlier)
+    "helm.sh/hook-delete-policy": before-hook-creation # Remove the secret before hook creation
+data:
+  HELM_RELEASE: "{{ .Release.Name }}"
+  {{- range $key, $val := .Values.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "comet-api.fullname" . }}-migrations
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade # Run migrations before install and upgrade
+    "helm.sh/hook-weight": "0" # Default weight
+    "helm.sh/hook-delete-policy": before-hook-creation # Delete previous job before creating a new one
+spec:
+  backoffLimit: 0 # Do not retry on failure
+  template:
+    spec:
+      restartPolicy: Never # Do not restart the job on failure
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ include "comet-api.fullname" . }}-migrations-image-pull-secret
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-migrations
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["bash", "-c", {{ .Values.migration.command }}]
+          envFrom:
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ include "comet-api.fullname" . }}-migrations
+            {{- end }}
+            {{- range $key, $val := .Values.additionalConfigMapNames }}
+            - configMapRef:
+                name: {{ $val }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "comet-api.fullname" . }}-migrations
+            {{- end }}
+            {{- range $key, $val := .Values.additionalSecretNames }}
+            - secretRef:
+                name: {{ $val }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+  {{- end}}

--- a/charts/comet-api-v3/templates/pod-disruption-budget.yaml
+++ b/charts/comet-api-v3/templates/pod-disruption-budget.yaml
@@ -1,0 +1,17 @@
+{{- if or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1)) }}
+apiVersion: "policy/v1"
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+  name: {{ include "comet-api.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "comet-api.selectorLabels" . | nindent 6 }}
+  {{ if .Values.autoscaling.enabled }}
+  minAvailable: {{ div .Values.autoscaling.minReplicas 2 }}
+  {{ else }}
+  minAvailable: {{ div .Values.replicaCount 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-api-v3/templates/rbac.yaml
+++ b/charts/comet-api-v3/templates/rbac.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "comet-api.serviceAccountName" . }}
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "comet-api.serviceAccountName" . }}-restricted
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "comet-api.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "comet-api.serviceAccountName" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-api.fullname" . }}-service-account-token
+  annotations:
+    kubernetes.io/service-account.name: {{ include "comet-api.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/comet-api-v3/templates/role.yaml
+++ b/charts/comet-api-v3/templates/role.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "comet-api.serviceAccountName" . }}
+rules:
+  - apiGroups: ["batch"] # Permissions for batch API group (used for managing cronjobs and jobs)
+    resources: ["cronjobs", "jobs"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""] # Permissions for core API group (used for managing pods)
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""] # Permissions for core API group (used for accessing pod logs)
+    resources: ["pods/log"]
+    verbs: ["get"]
+{{- end}}

--- a/charts/comet-api-v3/templates/route.yaml
+++ b/charts/comet-api-v3/templates/route.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "comet-api.fullname" . }}
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $val := .Values.route.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  host: "{{ .Values.domain }}"
+  port:
+    targetPort: http
+  {{- if .Values.route.tls.enabled }}
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "comet-api.fullname" . }}
+    weight: 100
+{{- end }}

--- a/charts/comet-api-v3/templates/secret.yaml
+++ b/charts/comet-api-v3/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-api.fullname" . }}
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $val := .Values.secrets }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-api-v3/templates/service.yaml
+++ b/charts/comet-api-v3/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "comet-api.fullname" . }}
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.containerPorts.http }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "comet-api.selectorLabels" . | nindent 4 }}

--- a/charts/comet-api-v3/templates/tests/test-connection.yaml
+++ b/charts/comet-api-v3/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "comet-api.fullname" . }}-test-connection"
+  labels:
+    {{- include "comet-api.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "comet-api.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/comet-api-v3/values.yaml
+++ b/charts/comet-api-v3/values.yaml
@@ -94,19 +94,19 @@ affinity: {}
 
 startupProbe: # Checks every periodSeconds for failureThreshold times
   httpGet:
-    path: /api/status/readiness
+    path: /api/healthcheck/ready
     port: http
   failureThreshold: 60
   periodSeconds: 3
 
 livenessProbe:
   httpGet:
-    path: /api/status/liveness
+    path: /api/healthcheck/live
     port: http
 
 readinessProbe:
   httpGet:
-    path: /api/status/readiness
+    path: /healthcheck/ready
     port: http
 
 cronJobs:

--- a/charts/comet-api-v3/values.yaml
+++ b/charts/comet-api-v3/values.yaml
@@ -1,0 +1,172 @@
+replicaCount: 1
+
+authproxy:
+  enabled: true
+
+image:
+  repository: nginx
+  hash: "" # will be used, if tag is not set
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecret: "" # will be overwritten by CI
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+autoMountServiceAccountToken: false
+
+service:
+  type: ClusterIP
+  port: 3000
+
+containerPorts:
+  http: 3000
+
+metrics:
+  enabled: false
+  containerPorts:
+    http: 9465
+
+ingress:
+  enabled: false
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt"
+
+route:
+  enabled: false
+  tls:
+    enabled: true
+  annotations: {}
+
+resources:
+  limits:
+    cpu: 2
+    memory: 256Mi
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+initContainers: []
+
+migration:
+  enabled: true
+  command: "npm run console:prod migrate"
+  resources:
+    limits:
+      cpu: 2
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+startupProbe: # Checks every periodSeconds for failureThreshold times
+  httpGet:
+    path: /api/status/readiness
+    port: http
+  failureThreshold: 60
+  periodSeconds: 3
+
+livenessProbe:
+  httpGet:
+    path: /api/status/liveness
+    port: http
+
+readinessProbe:
+  httpGet:
+    path: /api/status/readiness
+    port: http
+
+cronJobs:
+  build-checker:
+    enabled: false
+    command: "npm run console:prod check-changes"
+    schedule: "*/15 * * * *"
+    additionalLabels:
+      comet-dxp.com/build-checker: "true"
+    instanceNameOverride: ""
+    additionalAnnotations: {}
+    additionalPodLabels: {}
+    activeDeadlineSeconds: 600
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  blck-indx-mgrt-blks:
+    enabled: true
+    command: "npm run console:prod migrateBlocks && npm run console:prod createBlockIndexViews"
+    schedule: "0 0 30 2 *" # 30th of February, will never run automatically
+    activeDeadlineSeconds: 1200
+    instanceNameOverride: ""
+    additionalAnnotations: {}
+    additionalLabels: {}
+    additionalPodLabels: {}
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  fixtures:
+    enabled: false
+    suspend: true
+    command: "npm run fixtures:prod"
+    schedule: "0 0 30 2 *" # 30th of February, will never run automatically
+    activeDeadlineSeconds: 1200
+    instanceNameOverride: ""
+    additionalAnnotations: {}
+    additionalLabels: {}
+    additionalPodLabels: {}
+    resources:
+      limits:
+        cpu: 2
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 256Mi
+
+env:
+  NODE_ENV: "production"
+  NPM_RUN: "start:prod"
+  TZ: "Europe/Vienna"
+  SERVER_HOST: "0.0.0.0"
+additionalConfigMapNames: {}
+secrets: {}
+additionalSecretNames: {}
+additionalPodLabels: {}

--- a/charts/comet-site-preview-v2/.helmignore
+++ b/charts/comet-site-preview-v2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/comet-site-preview-v2/CHANGELOG.md
+++ b/charts/comet-site-preview-v2/CHANGELOG.md
@@ -1,0 +1,42 @@
+# comet-site-preview-v1
+
+## 1.2.0
+
+### Minor Changes
+
+-   d337b44: Increase CPU limit from 1 to 2
+
+## 1.1.0
+
+### Minor Changes
+
+-   41235fb: feat: add checksum annotations for auto-rollout on ConfigMap and Secret updates in Deployment templates
+
+## 1.0.1
+
+### Patch Changes
+
+-   4662d93: Remove dash after if to fix yaml formatting
+
+## 1.0.0
+
+### Major Changes
+
+-   0dd1ebb: - **BREAKING**: Avoid hardcoding values in configMaps or secrets and only generate them if they are not empty. Use `Values.env` or `Values.secrets` to fill them.
+    -   **BREAKING**: Disable `autoMountServiceAccountToken` by default.
+
+### Minor Changes
+
+-   0dd1ebb: - Add support for both tag and hash for images. Hash will be used if no tag is set.
+    -   Avoid excessive RAM usage for API, site, and site-preview.
+    -   Skip generating or using image-pull-secrets if none are set.
+    -   Replace the npm command with a direct call for site-preview build.
+    -   Introduce an option to add labels to pods.
+
+### Patch Changes
+
+-   0dd1ebb: - Add support for multiple secrets per deployment
+    -   Add option to disable automountServiceAccountToken
+    -   Remove entries from values.yaml that are not in use anymore
+    -   Replace template information in Chart.yaml with correct information
+    -   Change additionalLabels variable to additionalPodLabels for better understanding

--- a/charts/comet-site-preview-v2/Chart.yaml
+++ b/charts/comet-site-preview-v2/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: comet-site-preview
+description: Helm chart for a Comet Site-Preview Microservice
+type: application
+
+home: https://www.comet-dxp.com
+icon: https://avatars.githubusercontent.com/u/1012348?s=200&v=4
+
+maintainers:
+  - name: Daniel Karnutsch
+    email: daniel.karnutsch@vivid-planet.com
+  - name: Georg Schreglmann
+    email: georg.schreglmann@vivid-planet.com
+  - name: Franz Unger
+    email: franz.unger@vivid-planet.com
+  - name: Alexander Kaufmann
+    email: alexander.kaufmann@vivid-planet.com
+
+version: 1.2.0

--- a/charts/comet-site-preview-v2/package.json
+++ b/charts/comet-site-preview-v2/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "comet-site-preview-v2",
+    "private": true,
+    "version": "1.2.0"
+}

--- a/charts/comet-site-preview-v2/templates/_helpers.tpl
+++ b/charts/comet-site-preview-v2/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "comet-site-preview.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "comet-site-preview.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "comet-site-preview.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "comet-site-preview.labels" -}}
+helm.sh/chart: {{ include "comet-site-preview.chart" . }}
+{{ include "comet-site-preview.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "comet-site-preview.selectorLabels" -}}
+app: {{ include "comet-site-preview.fullname" . }}
+app.kubernetes.io/name: {{ include "comet-site-preview.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Prelogin Common labels
+*/}}
+{{- define "comet-site-preview.prelogin.labels" -}}
+helm.sh/chart: {{ include "comet-site-preview.chart" . }}
+{{ include "comet-site-preview.prelogin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Prelogin Selector labels
+*/}}
+{{- define "comet-site-preview.prelogin.selectorLabels" -}}
+app: {{ include "comet-site-preview.fullname" . }}-prelogin
+app.kubernetes.io/name: {{ include "comet-site-preview.name" . }}-prelogin
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/comet-site-preview-v2/templates/config-map.yaml
+++ b/charts/comet-site-preview-v2/templates/config-map.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "comet-site-preview.fullname" . }}
+  labels:
+    {{- include "comet-site-preview.labels" . | nindent 4 }}
+data:
+  {{- range $key, $val := .Values.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-site-preview-v2/templates/deployment.yaml
+++ b/charts/comet-site-preview-v2/templates/deployment.yaml
@@ -1,0 +1,131 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "comet-site-preview.fullname" . }}
+  labels:
+    {{- include "comet-site-preview.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "comet-site-preview.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.env }}
+        checksum/config-map: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.image.pullSecret }}
+        checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.secrets }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+      labels:
+        {{- include "comet-site-preview.selectorLabels" . | nindent 8 }}
+        {{- range $key, $val := .Values.additionalPodLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ include "comet-site-preview.fullname" . }}-image-pull-secret
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
+      initContainers:
+        - name: {{ .Chart.Name }}-build
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash", "-c", "next build"]
+          envFrom:
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ include "comet-site-preview.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalConfigMapNames }}
+            - configMapRef:
+                name:  {{ $val }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "comet-site-preview.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalSecretNames }}
+            - secretRef:
+                name:  {{ $val }}
+            {{- end }}
+          volumeMounts:
+            - mountPath: /opt/app-root/src/.next
+              name: document-root
+          resources:
+            {{- toYaml .Values.initContainer.resources | nindent 12 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ include "comet-site-preview.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalConfigMapNames }}
+            - configMapRef:
+                name:  {{ $val }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "comet-site-preview.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalSecretNames }}
+            - secretRef:
+                name:  {{ $val }}
+            {{- end }}
+          env:
+            - name: NPM_RUN
+              value: "{{ .Values.npmRun }}"
+          volumeMounts:
+            - mountPath: /opt/app-root/src/.next
+              name: document-root
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+        - name: document-root
+          emptyDir: {}

--- a/charts/comet-site-preview-v2/templates/image-pull-secret.yaml
+++ b/charts/comet-site-preview-v2/templates/image-pull-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.image.pullSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-site-preview.fullname" . }}-image-pull-secret
+  labels:
+    {{- include "comet-site-preview.labels" . | nindent 8 }}
+data:
+  .dockerconfigjson: {{ required "Missing image.pullSecret" .Values.image.pullSecret }}
+type: kubernetes.io/dockerconfigjson
+{{- end }}

--- a/charts/comet-site-preview-v2/templates/pod-disruption-budget.yaml
+++ b/charts/comet-site-preview-v2/templates/pod-disruption-budget.yaml
@@ -1,0 +1,13 @@
+{{- if (gt (.Values.replicaCount | int) 1) }}
+apiVersion: "policy/v1"
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "comet-site-preview.labels" . | nindent 4 }}
+  name: {{ include "comet-site-preview.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "comet-site-preview.selectorLabels" . | nindent 6 }}
+  minAvailable: 1
+{{- end }}

--- a/charts/comet-site-preview-v2/templates/secret.yaml
+++ b/charts/comet-site-preview-v2/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-site-preview.fullname" . }}
+  labels:
+    {{- include "comet-site-preview.labels" . | nindent 8 }}
+type: Opaque
+stringData:
+  {{- range $key, $val := .Values.secrets }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-site-preview-v2/templates/service.yaml
+++ b/charts/comet-site-preview-v2/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "comet-site-preview.fullname" . }}
+  labels:
+    {{- include "comet-site-preview.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "comet-site-preview.selectorLabels" . | nindent 4 }}

--- a/charts/comet-site-preview-v2/values.yaml
+++ b/charts/comet-site-preview-v2/values.yaml
@@ -39,9 +39,9 @@ initContainer:
       memory: 512Mi
 
 livenessProbe:
-  path: "/site/api/status"
+  path: /site/healthcheck/live
 
 readinessProbe:
-  path: "/site/api/status"
+  path: /site/healthcheck/ready
 
 autoMountServiceAccountToken: false

--- a/charts/comet-site-preview-v2/values.yaml
+++ b/charts/comet-site-preview-v2/values.yaml
@@ -1,0 +1,47 @@
+env:
+  NODE_ENV: "production"
+  TZ: "Europe/Vienna"
+additionalConfigMapNames: []
+secrets: {}
+additionalSecretNames: []
+additionalPodLabels: {}
+
+replicaCount: 2
+
+image:
+  repository: ""
+  hash: "" # will be used, if tag is not set
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecret: "" # will be overwritten by CI
+
+npmRun: "serve"
+
+service:
+  type: ClusterIP
+  port: 3000
+
+resources:
+  limits:
+    memory: 200Mi
+    cpu: 2
+  requests:
+    cpu: 50m
+    memory: 200Mi
+
+initContainer:
+  resources:
+    limits:
+      memory: 512Mi
+      cpu: 2
+    requests:
+      cpu: 50m
+      memory: 512Mi
+
+livenessProbe:
+  path: "/site/api/status"
+
+readinessProbe:
+  path: "/site/api/status"
+
+autoMountServiceAccountToken: false

--- a/charts/comet-site-v2/.helmignore
+++ b/charts/comet-site-v2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/comet-site-v2/CHANGELOG.md
+++ b/charts/comet-site-v2/CHANGELOG.md
@@ -1,0 +1,163 @@
+# comet-site-v1
+
+## 1.13.0
+
+### Minor Changes
+
+-   b3d23b7: Allow overriding the `comet-dxp.com/instance` label via `instanceNameOverride` value
+
+## 1.12.0
+
+### Minor Changes
+
+-   c9ffca1: Allow custom annotations for route
+-   793afc9: Allow custom annotaions for Deployments
+
+## 1.11.0
+
+### Minor Changes
+
+-   2eca0d8: Remove duplicated ServiceAccount/RoleBinding and fix CronJob serviceAccount reference
+
+## 1.10.0
+
+### Minor Changes
+
+-   1c2fca7: Allow to disable tls for routes
+
+## 1.9.1
+
+### Patch Changes
+
+-   7221731: Fix server host for deployed envs
+
+## 1.9.0
+
+### Minor Changes
+
+-   d337b44: Increase CPU limit from 1 to 2
+
+## 1.8.0
+
+### Minor Changes
+
+-   ea7c2b6: Manually create and mount service account secrets in cron jobs for api and site
+
+## 1.7.0
+
+### Minor Changes
+
+-   998ae6e: Add serviceAccountName configuration to site deployment
+
+## 1.6.1
+
+### Patch Changes
+
+-   4ccd534: Added missing {{- end }} to properly close the `with` block in the ServiceAccount template
+
+## 1.6.0
+
+### Minor Changes
+
+-   7d6e5db: Add sessionAffinity to site-service
+
+    Solves this problem:
+
+    -   During a pending upgrade two pods with two different versions (old and new) exist in parallel
+    -   The client makes a page request and is routed to the new pod
+    -   The returned HTML embeds links for assets to load
+    -   The client then makes requests to load these assets
+    -   The problem arises when these following requests are routed to the old pod, which answers with a 404
+
+    This changes reserves a 30 second time window where all subsequent requests within this time window are routed to the same pod.
+
+    Additional note: the opposite way (HTML comes from the old pod but subsequent requests are routed to the
+    new one because the old one does not exist anymore) is mitigated by caching the old assets in the CDN.
+
+-   c24e25d: Manually created a service account, service account secret and mounted the secret instead of using `autoMountServiceAccountToken`.
+
+## 1.5.0
+
+### Minor Changes
+
+-   e0fc0ee: Add configuration to expose metrics port for services
+
+## 1.4.0
+
+### Minor Changes
+
+-   41235fb: feat: add checksum annotations for auto-rollout on ConfigMap and Secret updates in Deployment templates
+
+## 1.3.0
+
+### Minor Changes
+
+-   Add configuration to expose metrics port
+
+## 1.2.0
+
+### Minor Changes
+
+-   Split selectorLabels into selectorLabels and selectorMatchLabels in comet-admin, comet-api and comet-site templates to modify pod labels without using additionalPodLabels parameter and without changing the matchLabels section
+
+## 1.1.0
+
+### Minor Changes
+
+-   76c35bb: Add option to mount .next folder as emptyDir
+
+## 1.0.3
+
+### Patch Changes
+
+-   d080998: Fix document-root mount if builder is not enabled
+
+## 1.0.2
+
+### Patch Changes
+
+-   67ee4af: Only render additional pvc labels, if there are any
+
+## 1.0.1
+
+### Patch Changes
+
+-   4662d93: Remove dash after if to fix yaml formatting
+
+## 1.0.0
+
+### Major Changes
+
+-   0dd1ebb: - **BREAKING**: Avoid hardcoding values in `configMaps`, `secrets`, `prelogin secrets`, or `prelogin envs`. Instead, use `Values.env`, `Values.secrets`, `Values.prelogin.secrets`, or `Values.prelogin.env` to fill them.
+    -   **BREAKING**: Disable `autoMountServiceAccountToken` by default, except for the `builder`.
+    -   **BREAKING**: Deactivate `builder` by default.
+
+### Minor Changes
+
+-   0dd1ebb: - Add support for security context for all cronjobs
+    -   Add possibility to add annotations to ingress (e.g. in use by NGINX Ingress Controller)
+    -   Add support for both tag and hash for images. Hash will be used if no tag is set
+    -   Don't overcommit RAM for api, site and site-preview
+    -   Don't generate/use image-pull-secrets if none are set
+    -   Replace npm with direct call for site init container
+    -   Add option to add labels to pods
+    -   Mount emptyDir in `.next` for building
+    -   Tar the finished build directly in the /mnt path and not in the current dir
+    -   Allow `additionalPodLabels` for SSG Builder Cronjob
+    -   Use emptyDir for kubectl rollout command after SSG build
+    -   Add compatibility for readonly systems by extracting SSG build in emptyDir tmp folder
+    -   Set automountServiceAccountToken for builder independent of setting for site
+
+### Patch Changes
+
+-   0dd1ebb: - Add support for multiple secrets per deployment
+    -   Only use pullsecret for site if present
+    -   Add option to disable automountServiceAccountToken
+    -   Add support for additional labels for site pvc
+    -   Remove entries from values.yaml that are not in use anymore
+    -   Replace template information in Chart.yaml with correct information
+    -   Add selectorLabels to build cronjob
+    -   Change additionalLabels variable to additionalPodLabels for better understanding
+    -   Set additionalPodLabels at correct space
+    -   Fix path for source of rsync
+    -   Change list syntax of prelogin envs

--- a/charts/comet-site-v2/Chart.yaml
+++ b/charts/comet-site-v2/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: comet-site
+description: Helm chart for a Comet Site Microservice
+type: application
+
+home: https://www.comet-dxp.com
+icon: https://avatars.githubusercontent.com/u/1012348?s=200&v=4
+
+maintainers:
+  - name: Daniel Karnutsch
+    email: daniel.karnutsch@vivid-planet.com
+  - name: Georg Schreglmann
+    email: georg.schreglmann@vivid-planet.com
+  - name: Franz Unger
+    email: franz.unger@vivid-planet.com
+  - name: Alexander Kaufmann
+    email: alexander.kaufmann@vivid-planet.com
+
+version: 1.13.0

--- a/charts/comet-site-v2/package.json
+++ b/charts/comet-site-v2/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "comet-site-v2",
+    "private": true,
+    "version": "1.13.0"
+}

--- a/charts/comet-site-v2/templates/_helpers.tpl
+++ b/charts/comet-site-v2/templates/_helpers.tpl
@@ -1,0 +1,93 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "comet-site.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "comet-site.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "comet-site.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "comet-site.labels" -}}
+helm.sh/chart: {{ include "comet-site.chart" . }}
+{{ include "comet-site.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "comet-site.selectorLabels" -}}
+app: {{ include "comet-site.fullname" . }}
+app.kubernetes.io/name: {{ include "comet-site.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector matchLabels
+*/}}
+{{- define "comet-site.selectorMatchLabels" -}}
+app: {{ include "comet-site.fullname" . }}
+app.kubernetes.io/name: {{ include "comet-site.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Prelogin Common labels
+*/}}
+{{- define "comet-site.prelogin.labels" -}}
+helm.sh/chart: {{ include "comet-site.chart" . }}
+{{ include "comet-site.prelogin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Prelogin Selector labels
+*/}}
+{{- define "comet-site.prelogin.selectorLabels" -}}
+app: {{ include "comet-site.fullname" . }}-prelogin
+app.kubernetes.io/name: {{ include "comet-site.name" . }}-prelogin
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "comet-site.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "comet-site.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/additional-ingresses.yaml
+++ b/charts/comet-site-v2/templates/additional-ingresses.yaml
@@ -1,0 +1,23 @@
+{{- if and (.Values.ingress.enabled) (.Values.additionalDomains) -}}
+{{- range $index, $additionalDomain := (splitList "," .Values.additionalDomains) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "comet-site.fullname" $ }}-additional-{{ $index }}
+  labels:
+    {{- include "comet-site.labels" $ | nindent 4 }}
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ $.Values.domain }}$request_uri"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: "{{ $additionalDomain }}"
+  tls:
+  - hosts:
+    - "{{ $additionalDomain }}"
+    secretName: {{ include "comet-site.fullname" $ }}-additional-{{ $index }}-cert
+{{- end -}}
+{{- end -}}
+ 

--- a/charts/comet-site-v2/templates/build-cron-job.yaml
+++ b/charts/comet-site-v2/templates/build-cron-job.yaml
@@ -1,0 +1,128 @@
+{{- if .Values.builder.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "comet-site.fullname" . }}-build
+  labels:
+    comet-dxp.com/builder: "true"
+    comet-dxp.com/instance: "{{ .Values.builder.instanceNameOverride | default .Release.Name }}"
+    {{- include "comet-site.labels" . | nindent 4 }}
+  annotations:
+    comet-dxp.com/content-scope: '{{- toJson .Values.contentScope }}'
+    comet-dxp.com/label: "{{ .Values.label }}"
+spec:
+  schedule: {{ .Values.builder.schedule }}
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    metadata:
+      annotations:
+        comet-dxp.com/trigger: "cronjob"
+        comet-dxp.com/content-scope: '{{- toJson .Values.contentScope }}'
+        comet-dxp.com/label: "{{ .Values.label }}"
+      labels:
+        comet-dxp.com/builder: "true"
+        comet-dxp.com/instance: "{{ .Values.builder.instanceNameOverride | default .Release.Name }}"
+        comet-dxp.com/parent-cron-job: {{ include "comet-site.fullname" . }}-build
+        {{- include "comet-site.selectorLabels" . | nindent 8 }}
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
+      ttlSecondsAfterFinished: 604800 # 7 days
+      template:
+        metadata:
+          labels:
+            {{- range $key, $val := .Values.builder.additionalPodLabels }}
+            {{ $key }}: {{ $val | quote }}
+            {{- end }}
+        spec:
+          {{- if .Values.image.pullSecret }}
+          imagePullSecrets:
+            - name: {{ include "comet-site.fullname" . }}-image-pull-secret
+          {{- end }}
+          restartPolicy: "Never"
+          serviceAccountName: {{ include "comet-site.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.builder.podSecurityContext | nindent 12 }}
+          automountServiceAccountToken: {{ .Values.builder.autoMountServiceAccountToken }}
+          containers:
+            - name: {{ .Chart.Name }}-build
+              securityContext:
+                {{- toYaml .Values.builder.securityContext | nindent 16 }}
+              {{- if .Values.image.tag }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              {{- else }}
+              image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+              {{- end }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["bash", "-c"]
+              args:
+                - set -e;
+                  export BUILD_FILE=/tmp/build_$(date +%F_%T).tar;
+                  npm run next-build;
+                  tar --force-local -cf $BUILD_FILE -C .next .;
+                  rsync --remove-source-files $BUILD_FILE /mnt/generated-sites/;
+                  rm -f $(ls -1dt /mnt/generated-sites/* | tail -n +3);
+                  curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /tmp/kubectl;
+                  chmod u+x /tmp/kubectl;
+                  NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace);
+                  /tmp/kubectl rollout restart deployment {{ include "comet-site.fullname" . }} -n $NAMESPACE;
+              env:
+                - name: KUBECTL_VERSION
+                  value: "{{ .Values.builder.kubectlVersion }}"
+              {{- with .Values.builder.extraEnv }}
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              envFrom:
+                {{- if .Values.env }}
+                - configMapRef:
+                    name: {{ include "comet-site.fullname" . }}
+                {{- end }}
+                {{- range $key, $val := .Values.additionalConfigMapNames }}
+                - configMapRef:
+                    name:  {{ $val }}
+                {{- end }}
+                {{- if .Values.secrets }}
+                - secretRef:
+                    name: {{ include "comet-site.fullname" . }}
+                {{- end }}
+                {{- range $key, $val := .Values.additionalSecretNames }}
+                - secretRef:
+                    name:  {{ $val }}
+                {{- end }}
+              volumeMounts:
+                - mountPath: /opt/app-root/src/.next
+                  name: document-root
+                - mountPath: /mnt/generated-sites/
+                  name: generated-sites
+                - mountPath: /tmp
+                  name: tmp
+                {{- if .Values.serviceAccount.create }}
+                - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+                  name: "service-account"
+                  readOnly: true
+                {{- end }}
+              resources:
+                {{- toYaml .Values.builder.resources | nindent 16 }}
+          volumes:
+            {{- if .Values.serviceAccount.create }}
+            - name: "service-account"
+              secret:
+                secretName: {{ include "comet-site.fullname" . }}-service-account-token
+            {{- end }}
+            - name: document-root
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}
+            - name: generated-sites
+              persistentVolumeClaim:
+{{- if and .Values.pvc.create .Values.pvc.name }}
+                claimName: {{ .Values.pvc.name }}
+{{- else if .Values.pvc.create }}
+                claimName: {{ include "comet-site.fullname" . }}-build
+{{- else }}
+                claimName: {{ .Values.persistence.existingClaim }}
+{{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/config-map.yaml
+++ b/charts/comet-site-v2/templates/config-map.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "comet-site.fullname" . }}
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+data:
+  {{- range $key, $val := .Values.env }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/deployment.yaml
+++ b/charts/comet-site-v2/templates/deployment.yaml
@@ -1,0 +1,209 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "comet-site.fullname" . }}
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "comet-site.selectorMatchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.env }}
+        checksum/config-map: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.image.pullSecret }}
+        checksum/image-pull-secret: {{ include (print $.Template.BasePath "/image-pull-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.secrets }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- range $key, $val := .Values.podAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      labels:
+        {{- include "comet-site.selectorLabels" . | nindent 8 }}
+        {{- range $key, $val := .Values.additionalPodLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ include "comet-site.fullname" . }}-image-pull-secret
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: {{ .Values.autoMountServiceAccountToken }}
+      serviceAccountName: {{ include "comet-site.serviceAccountName" . }}
+      {{- if or (.Values.builder.enabled) (.Values.initContainer.enabled) }}
+      initContainers:
+        - name: {{ .Chart.Name }}-copy
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - set -e;
+              export DESIRED_VERSION=$(ls -t /mnt/generated-sites/ | head -1);
+              if [ -z $DESIRED_VERSION ]; then
+                echo "No build available --> building locally";
+                node preBuild/build/preBuild/src/publicGenerator/generate.js && next build;
+              else
+                mkdir -p .next;
+                mkdir -p /tmp/site-build;
+                tar -xf /mnt/generated-sites/$DESIRED_VERSION --force-local -m --no-overwrite-dir -C /tmp/site-build;
+                mv /tmp/site-build/* .next/;
+                rm -r /tmp/site-build;
+              fi;
+          envFrom:
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ include "comet-site.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalConfigMapNames }}
+            - configMapRef:
+                name:  {{ $val }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "comet-site.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalSecretNames }}
+            - secretRef:
+                name:  {{ $val }}
+            {{- end }}
+          {{- with .Values.initContainer.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.builder.enabled }}
+            - mountPath: /mnt/generated-sites/
+              name: generated-sites
+            - mountPath: /tmp
+              name: tmp
+          {{- end }}
+          {{- if .Values.mountEmptyDirAsNextFolder }}
+            - mountPath: /opt/app-root/src/.next
+              name: document-root
+          {{- end }}
+          resources:
+            {{- toYaml .Values.initContainer.resources | nindent 12 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.hash }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            {{- if .Values.env }}
+            - configMapRef:
+                name: {{ include "comet-site.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalConfigMapNames }}
+            - configMapRef:
+                name:  {{ $val }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "comet-site.fullname" . }}
+            {{- end }}
+            {{- range $key, $val := .Values.additionalSecretNames }}
+            - secretRef:
+                name:  {{ $val }}
+            {{- end }}
+          env:
+            - name: NPM_RUN
+              value: "{{ .Values.npmRun }}"
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.builder.enabled }}
+            - mountPath: /mnt/generated-sites/
+              name: generated-sites
+          {{- end }}
+          {{- if .Values.mountEmptyDirAsNextFolder }}
+            - mountPath: /opt/app-root/src/.next
+              name: document-root
+          {{- end }}
+          {{- if .Values.serviceAccount.create }}
+            - mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+              name: "service-account"
+              readOnly: true
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.containerPorts.http }}
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+              httpHeaders:
+              - name: x-cdn-origin-check
+                value: "{{ .Values.cdn.originHeader }}"
+          readinessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+              httpHeaders:
+              - name: x-cdn-origin-check
+                value: "{{ .Values.cdn.originHeader }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+        {{- if .Values.serviceAccount.create }}
+        - name: "service-account"
+          secret:
+            secretName: {{ include "comet-site.fullname" . }}-service-account-token
+        {{- end }}
+    {{- if .Values.builder.enabled }}
+        - name: generated-sites
+          persistentVolumeClaim:
+          {{- if and .Values.pvc.create .Values.pvc.name }}
+            claimName: {{ .Values.pvc.name }}
+          {{- else if .Values.pvc.create }}
+            claimName: {{ include "comet-site.fullname" . }}-build
+          {{- else }}
+            claimName: {{ .Values.persistence.existingClaim }}
+          {{- end }}
+        - name: tmp
+          emptyDir: {}
+    {{- end }}
+    {{- if .Values.mountEmptyDirAsNextFolder }}
+        - name: document-root
+          emptyDir: {}
+    {{- end }}

--- a/charts/comet-site-v2/templates/deployment.yaml
+++ b/charts/comet-site-v2/templates/deployment.yaml
@@ -158,14 +158,14 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /api/status
+              path: /healthcheck/live
               port: http
               httpHeaders:
               - name: x-cdn-origin-check
                 value: "{{ .Values.cdn.originHeader }}"
           readinessProbe:
             httpGet:
-              path: /api/status
+              path: /healthcheck/ready
               port: http
               httpHeaders:
               - name: x-cdn-origin-check

--- a/charts/comet-site-v2/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/comet-site-v2/templates/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "comet-site.fullname" . }}
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "comet-site.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/image-pull-secret.yaml
+++ b/charts/comet-site-v2/templates/image-pull-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.image.pullSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-site.fullname" . }}-image-pull-secret
+  labels:
+    {{- include "comet-site.labels" . | nindent 8 }}
+data:
+  .dockerconfigjson: {{ required "Missing image.pullSecret" .Values.image.pullSecret }}
+type: kubernetes.io/dockerconfigjson
+{{- end }}

--- a/charts/comet-site-v2/templates/main-ingress.yaml
+++ b/charts/comet-site-v2/templates/main-ingress.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "comet-site.fullname" . }}-main
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $val := .Values.ingress.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+
+spec:
+  ingressClassName: nginx
+  rules:
+  {{- if .Values.domains }}
+  {{- range .Values.domains }}
+  - host: "{{ . }}"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "comet-site.fullname" $ }}
+            port:
+              number: 3000
+  {{- end }}
+  {{- else if .Values.cdn.enabled }}
+  - host: "{{ .Values.internalDomain }}"
+  {{- else }}
+  - host: "{{ .Values.domain }}"
+  {{- end }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+          {{- if .Values.prelogin.enabled }}
+            name: {{ include "comet-site.fullname" . }}-prelogin
+          {{- else }}
+            name: {{ include "comet-site.fullname" . }}
+          {{- end }}
+            port:
+              number: 3000
+
+  tls:
+  - hosts:
+{{- if .Values.domains }}
+  {{- range .Values.domains }}
+    - "{{ . }}"
+  {{- end }}
+{{- else if .Values.cdn.enabled }}
+    - "{{ .Values.internalDomain }}"
+{{- else }}
+    - "{{ .Values.domain }}"
+{{- end }}
+    secretName: {{ include "comet-site.fullname" . }}-main-cert
+{{- end }}

--- a/charts/comet-site-v2/templates/persistent-volume-claim.yaml
+++ b/charts/comet-site-v2/templates/persistent-volume-claim.yaml
@@ -1,0 +1,28 @@
+{{- if and (.Values.pvc.create) (.Values.builder.enabled) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{- if .Values.pvc.name }}
+  name: {{ .Values.pvc.name }}
+  {{- else }}
+  name: {{ include "comet-site.fullname" . }}-build
+  {{- end }}
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+    {{- if .Values.pvc.additionalLabels }}
+    {{- toYaml .Values.pvc.additionalLabels | nindent 4 }}
+    {{- end }}
+  {{- with .Values.pvc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteMany
+{{- if .Values.pvc.storageClass }}
+  storageClassName: {{ .Values.pvc.storageClass }}
+{{- end }}
+  resources:
+    requests:
+      storage: 10Gi
+{{- end }}

--- a/charts/comet-site-v2/templates/pod-disruption-budget.yaml
+++ b/charts/comet-site-v2/templates/pod-disruption-budget.yaml
@@ -1,0 +1,18 @@
+
+{{- if or (and .Values.autoscaling.enabled (gt (.Values.autoscaling.minReplicas | int) 1)) (and (not .Values.autoscaling.enabled) (gt (.Values.replicaCount | int) 1)) }}
+apiVersion: "policy/v1"
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+  name: {{ include "comet-site.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "comet-site.selectorLabels" . | nindent 6 }}
+  {{ if .Values.autoscaling.enabled }}
+  minAvailable: {{ div .Values.autoscaling.minReplicas 2 }}
+  {{ else }}
+  minAvailable: {{ div .Values.replicaCount 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/prelogin-deployment.yml
+++ b/charts/comet-site-v2/templates/prelogin-deployment.yml
@@ -58,12 +58,12 @@ spec:
           livenessProbe:
             initialDelaySeconds: 10
             httpGet:
-              path: /login/api/status
+              path: /login/healthcheck/live
               port: http
           readinessProbe:
             initialDelaySeconds: 10
             httpGet:
-              path: /login/api/status
+              path: /login/healthcheck/ready
               port: http
           resources:
             {{- toYaml .Values.prelogin.resources | nindent 12 }}

--- a/charts/comet-site-v2/templates/prelogin-deployment.yml
+++ b/charts/comet-site-v2/templates/prelogin-deployment.yml
@@ -1,0 +1,82 @@
+{{- if .Values.prelogin.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "comet-site.fullname" . }}-prelogin
+  labels:
+    {{- include "comet-site.prelogin.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.prelogin.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "comet-site.prelogin.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if and (.Values.prelogin.enabled) (.Values.prelogin.secrets) }}
+        checksum/prelogin-secret: {{ include (print $.Template.BasePath "/prelogin-secret.yaml") . | sha256sum }}
+        {{- end }}
+      labels:
+        {{- include "comet-site.prelogin.selectorLabels" . | nindent 8 }}
+        {{- range $key, $val := .Values.prelogin.additionalPodLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ include "comet-site.fullname" . }}-image-pull-secret
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.prelogin.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: {{ .Values.prelogin.autoMountServiceAccountToken }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.prelogin.securityContext | nindent 12 }}
+          {{- if .Values.prelogin.image.tag }}
+          image: "{{ .Values.prelogin.image.repository }}:{{ .Values.prelogin.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.prelogin.image.repository }}@{{ .Values.prelogin.image.hash }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.prelogin.image.pullPolicy }}
+          env:
+            -   name: NODE_ENV
+                value: "production"
+            -   name: NPM_RUN
+                value: "start"
+            {{- range $key, $val := .Values.prelogin.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "comet-site.fullname" . }}-prelogin
+          ports:
+            - name: http
+              containerPort: 3010
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: /login/api/status
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: /login/api/status
+              port: http
+          resources:
+            {{- toYaml .Values.prelogin.resources | nindent 12 }}
+      {{- with .Values.prelogin.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.prelogin.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.prelogin.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/prelogin-secret.yaml
+++ b/charts/comet-site-v2/templates/prelogin-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (.Values.prelogin.enabled) (.Values.prelogin.secrets) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-site.fullname" . }}-prelogin
+  labels:
+    {{- include "comet-site.prelogin.labels" . | nindent 8 }}
+type: Opaque
+stringData:
+  {{- range $key, $val := .Values.prelogin.secrets }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/prelogin-service.yml
+++ b/charts/comet-site-v2/templates/prelogin-service.yml
@@ -1,0 +1,17 @@
+{{- if .Values.prelogin.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "comet-site.fullname" . }}-prelogin
+  labels:
+    {{- include "comet-site.prelogin.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.prelogin.service.type }}
+  ports:
+    - port: {{ .Values.prelogin.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "comet-site.prelogin.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/comet-site-v2/templates/rbac.yaml
+++ b/charts/comet-site-v2/templates/rbac.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "comet-site.serviceAccountName" . }}
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "comet-site.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "comet-site.serviceAccountName" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-site.fullname" . }}-service-account-token
+  annotations:
+    kubernetes.io/service-account.name: {{ include "comet-site.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/comet-site-v2/templates/route.yaml
+++ b/charts/comet-site-v2/templates/route.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "comet-site.fullname" . }}
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $val := .Values.route.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+{{- if .Values.cdn.enabled }}
+  host: "{{ .Values.internalDomain }}"
+{{- else }}
+  host: "{{ .Values.domain }}"
+{{- end }}
+  {{- if .Values.route.tls.enabled }}
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  {{- end }}
+{{- if .Values.prelogin.enabled }}
+  port:
+    targetPort: 3010
+  to:
+      kind: Service
+      name: {{ include "comet-site.fullname" . }}-prelogin
+      weight: 100
+{{ else }}
+  port:
+    targetPort: 3000
+  to:
+    kind: Service
+    name: {{ include "comet-site.fullname" . }}
+    weight: 100
+{{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/secret.yaml
+++ b/charts/comet-site-v2/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comet-site.fullname" . }}
+  labels:
+    {{- include "comet-site.labels" . | nindent 8 }}
+type: Opaque
+stringData:
+  {{- range $key, $val := .Values.secrets }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/comet-site-v2/templates/service.yaml
+++ b/charts/comet-site-v2/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "comet-site.fullname" . }}
+  labels:
+    {{- include "comet-site.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.service.sessionAffinityTimeoutSeconds }}
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.service.sessionAffinityTimeoutSeconds }}
+  {{- end }}
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.containerPorts.http }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "comet-site.selectorLabels" . | nindent 4 }}

--- a/charts/comet-site-v2/values.yaml
+++ b/charts/comet-site-v2/values.yaml
@@ -1,0 +1,165 @@
+contentScope: {}
+label: ""
+
+env:
+  NODE_ENV: "production"
+  TZ: "Europe/Vienna"
+  SERVER_HOST: "0.0.0.0"
+additionalConfigMapNames: []
+secrets: {}
+additionalSecretNames: []
+additionalPodLabels: {}
+
+replicaCount: 1
+
+image:
+  repository: ""
+  hash: "" # will be used, if tag is not set
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecret: "" # will be overwritten by CI
+
+npmRun: "serve"
+
+service:
+  type: ClusterIP
+  port: 3000
+  sessionAffinityTimeoutSeconds: 30
+
+metrics:
+  enabled: false
+  containerPorts:
+    http: 9464
+
+resources:
+  limits:
+    memory: 200Mi
+    cpu: 2
+  requests:
+    cpu: 50m
+    memory: 200Mi
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+
+podAnnotations: {}
+
+initContainer:
+  enabled: false # can be used to enable initContainer even though builder is disabled
+
+  resources:
+    limits:
+      memory: 512Mi
+      cpu: 2
+    requests:
+      cpu: 50m
+      memory: 512Mi
+
+builder:
+  enabled: false
+  instanceNameOverride: ""
+
+  schedule: "0 6 * * *"
+
+  autoMountServiceAccountToken: false
+
+  additionalPodLabels: {}
+
+  kubectlVersion: "1.21.14"
+  podSecurityContext:
+    {}
+    # fsGroup: 2000
+  securityContext:
+    {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources:
+    limits:
+      memory: 512Mi
+      cpu: 500m
+    requests:
+      cpu: 500m
+      memory: 512Mi
+
+prelogin:
+  enabled: false
+  replicaCount: 1
+  requiredUserDomain: ""
+  autoMountServiceAccountToken: false
+  additionalPodLabels: {}
+  secrets: {}
+
+  image:
+    repository: "" # will be overwritten by CI
+    hash: v2 # will be overwritten by CI
+    pullPolicy: IfNotPresent
+    pullSecret: "" # will be overwritten by CI
+
+  securityContext:
+    {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  resources:
+    limits:
+      memory: 128Mi
+      cpu: "500m"
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+autoMountServiceAccountToken: false
+
+route:
+  enabled: false
+  tls:
+    enabled: true
+  annotations:
+    haproxy.router.openshift.io/disable_cookies: "true"
+    haproxy.router.openshift.io/balance: "roundrobin"
+
+ingress:
+  enabled: false
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt"
+
+domains: [] # one of these 3 has to be set for ingress to work
+domain: "" # one of these 3 has to be set for ingress to work. This is here for compatibility reasons and can be removed in the next major release
+internalDomain: "" # one of these 3 has to be set for ingress to work. This is here for compatibility reasons and can be removed in the next major release
+
+cdn:
+  enabled: false
+  originHeader: ""
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 80
+
+pvc:
+  create: false
+  annotations: {}
+  additionalPodLabels: {}
+  additionalLabels: {}
+
+persistence:
+  existingClaim: ""
+
+mountEmptyDirAsNextFolder: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,16 +18,22 @@
             }
         },
         "charts/comet-admin-v1": {
-            "version": "1.8.0"
+            "version": "1.8.1"
+        },
+        "charts/comet-admin-v2": {
+            "version": "1.8.1"
         },
         "charts/comet-api-v1": {
-            "version": "1.15.0"
+            "version": "1.18.0"
         },
         "charts/comet-api-v2": {
-            "version": "1.15.0"
+            "version": "2.4.0"
+        },
+        "charts/comet-api-v3": {
+            "version": "2.4.0"
         },
         "charts/comet-ingress-v1": {
-            "version": "1.0.1"
+            "version": "1.2.0"
         },
         "charts/comet-keda-v1": {
             "version": "1.1.0"
@@ -35,11 +41,17 @@
         "charts/comet-site-preview-v1": {
             "version": "1.2.0"
         },
+        "charts/comet-site-preview-v2": {
+            "version": "1.2.0"
+        },
         "charts/comet-site-v1": {
-            "version": "1.11.0"
+            "version": "1.13.0"
+        },
+        "charts/comet-site-v2": {
+            "version": "1.13.0"
         },
         "charts/imgproxy": {
-            "version": "0.10.2"
+            "version": "1.0.0"
         },
         "node_modules/@babel/runtime": {
             "version": "7.26.0",
@@ -561,12 +573,20 @@
             "resolved": "charts/comet-admin-v1",
             "link": true
         },
+        "node_modules/comet-admin-v2": {
+            "resolved": "charts/comet-admin-v2",
+            "link": true
+        },
         "node_modules/comet-api-v1": {
             "resolved": "charts/comet-api-v1",
             "link": true
         },
         "node_modules/comet-api-v2": {
             "resolved": "charts/comet-api-v2",
+            "link": true
+        },
+        "node_modules/comet-api-v3": {
+            "resolved": "charts/comet-api-v3",
             "link": true
         },
         "node_modules/comet-ingress-v1": {
@@ -581,8 +601,16 @@
             "resolved": "charts/comet-site-preview-v1",
             "link": true
         },
+        "node_modules/comet-site-preview-v2": {
+            "resolved": "charts/comet-site-preview-v2",
+            "link": true
+        },
         "node_modules/comet-site-v1": {
             "resolved": "charts/comet-site-v1",
+            "link": true
+        },
+        "node_modules/comet-site-v2": {
+            "resolved": "charts/comet-site-v2",
             "link": true
         },
         "node_modules/commander": {


### PR DESCRIPTION
## Summary

- Switches `livenessProbe`/`readinessProbe`/`startupProbe` paths in the new major chart versions (`comet-admin-v2`, `comet-api-v3`, `comet-site-v2` incl. prelogin, `comet-site-preview-v2`) to dedicated `/healthcheck/*` endpoints.
- Reduces noise from health-check requests in monitoring tools (e.g. Sentry false positives that can't be filtered via inbound filters).
- Includes a major changeset documenting the breaking change — applications must expose the new endpoints before upgrading.

## Test plan

- [ ] `helm template` each touched chart and verify the rendered probe paths
- [ ] Verify changeset is picked up by the release workflow (major bump for all 4 charts)
- [ ] Smoke-test deploy of one chart against an app that exposes the new endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)