### PR TITLE
fix(comet-api-v3): add missing /api prefix to readinessProbe path

### DIFF
--- a/.changeset/fix-api-v3-readiness-prefix.md
+++ b/.changeset/fix-api-v3-readiness-prefix.md
@@ -1,0 +1,5 @@
+---
+"comet-api-v3": patch
+---
+
+Fix `readinessProbe.httpGet.path` in `comet-api-v3` — was `/healthcheck/ready`, but the NestJS app uses the global `api` prefix, so the correct path is `/api/healthcheck/ready` (matching `livenessProbe` and `startupProbe`). The previous value caused readiness probes to return 404 and pods never became ready.

--- a/charts/comet-api-v3/values.yaml
+++ b/charts/comet-api-v3/values.yaml
@@ -106,7 +106,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /healthcheck/ready
+    path: /api/healthcheck/ready
     port: http
 
 cronJobs:


### PR DESCRIPTION
## Summary

The `readinessProbe.httpGet.path` in `comet-api-v3/values.yaml` was set to `/healthcheck/ready`, missing the `/api` prefix that the NestJS app applies via `app.setGlobalPrefix("api")`. The `startupProbe` and `livenessProbe` already had the correct `/api/healthcheck/{ready,live}` paths — only `readinessProbe` was wrong.

Symptom in OpenShift after upgrading to `comet-api-v3`:

```
Startup probe failed: ... connection refused      # transient during bootstrap, then OK
Readiness probe failed: HTTP probe failed with statuscode: 404
```

Pods stayed in `Running 0/1` indefinitely with no restarts, because the readiness probe kept hitting a non-existent path.

This was introduced in the `/healthcheck/*` migration (#194) — the changeset/CHANGELOG even documented the bug verbatim (`readinessProbe: /healthcheck/ready`), suggesting it was a copy-paste slip from the prefix-less site/admin charts.

## Changes

- `charts/comet-api-v3/values.yaml`: `readinessProbe.httpGet.path: /healthcheck/ready` → `/api/healthcheck/ready`
- Changeset: `patch` bump for `comet-api-v3`

## Test plan

- [x] Deployed `campaign-manager` int-api on the fixed chart — readiness probe returns 200, pod becomes ready
- [x] Existing consumers upgrading to the patched `3.0.x` no longer see persistent readiness 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)