### PR TITLE
Add additionalLabels value to set custom labels on Deployment metadata

### DIFF
--- a/.changeset/additional-labels-deployment.md
+++ b/.changeset/additional-labels-deployment.md
@@ -1,0 +1,13 @@
+---
+"comet-admin-v1": minor
+"comet-admin-v2": minor
+"comet-api-v1": minor
+"comet-api-v2": minor
+"comet-api-v3": minor
+"comet-site-v1": minor
+"comet-site-v2": minor
+"comet-site-preview-v1": minor
+"comet-site-preview-v2": minor
+---
+
+Add `additionalDeploymentLabels` value to set custom labels on the Deployment metadata (e.g. `sablier.enable`/`sablier.group`)

--- a/charts/comet-admin-v1/templates/deployment.yaml
+++ b/charts/comet-admin-v1/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-admin.fullname" . }}
   labels:
     {{- include "comet-admin.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-admin-v1/values.yaml
+++ b/charts/comet-admin-v1/values.yaml
@@ -74,3 +74,4 @@ tolerations: []
 affinity: {}
 
 additionalPodLabels: {}
+additionalDeploymentLabels: {}

--- a/charts/comet-admin-v2/templates/deployment.yaml
+++ b/charts/comet-admin-v2/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-admin.fullname" . }}
   labels:
     {{- include "comet-admin.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-admin-v2/values.yaml
+++ b/charts/comet-admin-v2/values.yaml
@@ -74,3 +74,4 @@ tolerations: []
 affinity: {}
 
 additionalPodLabels: {}
+additionalDeploymentLabels: {}

--- a/charts/comet-api-v1/templates/deployment.yaml
+++ b/charts/comet-api-v1/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-api.fullname" . }}
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-api-v1/values.yaml
+++ b/charts/comet-api-v1/values.yaml
@@ -168,3 +168,4 @@ additionalConfigMapNames: {}
 secrets: {}
 additionalSecretNames: {}
 additionalPodLabels: {}
+additionalDeploymentLabels: {}

--- a/charts/comet-api-v2/templates/deployment.yaml
+++ b/charts/comet-api-v2/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-api.fullname" . }}
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-api-v2/values.yaml
+++ b/charts/comet-api-v2/values.yaml
@@ -170,3 +170,4 @@ additionalConfigMapNames: {}
 secrets: {}
 additionalSecretNames: {}
 additionalPodLabels: {}
+additionalDeploymentLabels: {}

--- a/charts/comet-api-v3/templates/deployment.yaml
+++ b/charts/comet-api-v3/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-api.fullname" . }}
   labels:
     {{- include "comet-api.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-api-v3/values.yaml
+++ b/charts/comet-api-v3/values.yaml
@@ -170,3 +170,4 @@ additionalConfigMapNames: {}
 secrets: {}
 additionalSecretNames: {}
 additionalPodLabels: {}
+additionalDeploymentLabels: {}

--- a/charts/comet-site-preview-v1/templates/deployment.yaml
+++ b/charts/comet-site-preview-v1/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-site-preview.fullname" . }}
   labels:
     {{- include "comet-site-preview.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/comet-site-preview-v1/values.yaml
+++ b/charts/comet-site-preview-v1/values.yaml
@@ -5,6 +5,7 @@ additionalConfigMapNames: []
 secrets: {}
 additionalSecretNames: []
 additionalPodLabels: {}
+additionalDeploymentLabels: {}
 
 replicaCount: 2
 

--- a/charts/comet-site-preview-v2/templates/deployment.yaml
+++ b/charts/comet-site-preview-v2/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-site-preview.fullname" . }}
   labels:
     {{- include "comet-site-preview.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/comet-site-preview-v2/values.yaml
+++ b/charts/comet-site-preview-v2/values.yaml
@@ -5,6 +5,7 @@ additionalConfigMapNames: []
 secrets: {}
 additionalSecretNames: []
 additionalPodLabels: {}
+additionalDeploymentLabels: {}
 
 replicaCount: 2
 

--- a/charts/comet-site-v1/templates/deployment.yaml
+++ b/charts/comet-site-v1/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-site.fullname" . }}
   labels:
     {{- include "comet-site.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-site-v1/templates/prelogin-deployment.yml
+++ b/charts/comet-site-v1/templates/prelogin-deployment.yml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "comet-site.fullname" . }}-prelogin
   labels:
     {{- include "comet-site.prelogin.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.prelogin.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
   replicas: {{ .Values.prelogin.replicaCount }}
   selector:

--- a/charts/comet-site-v1/values.yaml
+++ b/charts/comet-site-v1/values.yaml
@@ -9,6 +9,7 @@ additionalConfigMapNames: []
 secrets: {}
 additionalSecretNames: []
 additionalPodLabels: {}
+additionalDeploymentLabels: {}
 
 replicaCount: 1
 
@@ -95,6 +96,7 @@ prelogin:
   requiredUserDomain: ""
   autoMountServiceAccountToken: false
   additionalPodLabels: {}
+  additionalDeploymentLabels: {}
   secrets: {}
 
   image:

--- a/charts/comet-site-v2/templates/deployment.yaml
+++ b/charts/comet-site-v2/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "comet-site.fullname" . }}
   labels:
     {{- include "comet-site.labels" . | nindent 4 }}
+{{- range $key, $val := .Values.additionalDeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-site-v2/values.yaml
+++ b/charts/comet-site-v2/values.yaml
@@ -9,6 +9,7 @@ additionalConfigMapNames: []
 secrets: {}
 additionalSecretNames: []
 additionalPodLabels: {}
+additionalDeploymentLabels: {}
 
 replicaCount: 1
 


### PR DESCRIPTION
## Motivation

To use [Sablier](https://sablierapp.dev/) for scale-to-zero, deployments need labels on the Deployment object itself (not only on the pods), e.g.:

```
kubectl label deployments --all --namespace=$NAMESPACE "sablier.enable=true" "sablier.group=$NAMESPACE" --overwrite
```

This should be possible declaratively via chart values instead of imperative kubectl commands.

## Changes

- Add a new `additionalDeploymentLabels` value to all comet charts (comet-admin-v1/v2, comet-api-v1/v2/v3, comet-site-v1/v2, comet-site-preview-v1/v2) that renders custom labels into the Deployment `metadata.labels`, analogous to the existing `additionalPodLabels` pattern.
- Default is `additionalDeploymentLabels: {}`, so this is fully backwards compatible.

Usage:

```yaml
additionalDeploymentLabels:
  sablier.enable: "true"
  sablier.group: "my-namespace"
```

Notes:
- The charts contain no StatefulSets, only Deployments — so nothing to adapt there.
- `imgproxy` already supports Deployment labels via `resources.common.labels` and is unchanged.

Verified by rendering all 9 charts with `helm template` and sablier labels set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)