### PR TITLE
Add zero-scaling support via Sablier

### DIFF
--- a/.changeset/additional-annotations-deployment.md
+++ b/.changeset/additional-annotations-deployment.md
@@ -1,0 +1,13 @@
+---
+"comet-admin-v1": minor
+"comet-admin-v2": minor
+"comet-api-v1": minor
+"comet-api-v2": minor
+"comet-api-v3": minor
+"comet-site-v1": minor
+"comet-site-v2": minor
+"comet-site-preview-v1": minor
+"comet-site-preview-v2": minor
+---
+
+Add `additionalDeploymentAnnotations` value to set custom annotations on the Deployment metadata. Complements `additionalDeploymentLabels` for values that are not valid as labels (e.g. `sablier.running-hours: "09:00-17:00"`).

--- a/.changeset/ingress-zero-scaling.md
+++ b/.changeset/ingress-zero-scaling.md
@@ -1,0 +1,5 @@
+---
+"comet-ingress-v1": minor
+---
+
+Add `zeroScaling` values block for scale-to-zero support via [Sablier](https://sablierapp.dev/). When `zeroScaling.enabled` is set, the chart renders a Traefik middleware using the Sablier plugin (dynamic strategy with waiting page) and attaches it to all ingresses via the `traefik.ingress.kubernetes.io/router.middlewares` annotation, so incoming requests start the deployments of the configured Sablier group on demand. The group defaults to the release namespace; `sablierUrl`, `sessionDuration`, `failOpen`, `ignoreUserAgent` and the waiting page title are configurable.

--- a/charts/comet-admin-v1/templates/deployment.yaml
+++ b/charts/comet-admin-v1/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-admin-v1/values.yaml
+++ b/charts/comet-admin-v1/values.yaml
@@ -75,3 +75,4 @@ affinity: {}
 
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}

--- a/charts/comet-admin-v2/templates/deployment.yaml
+++ b/charts/comet-admin-v2/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-admin-v2/values.yaml
+++ b/charts/comet-admin-v2/values.yaml
@@ -75,3 +75,4 @@ affinity: {}
 
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}

--- a/charts/comet-api-v1/templates/deployment.yaml
+++ b/charts/comet-api-v1/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-api-v1/values.yaml
+++ b/charts/comet-api-v1/values.yaml
@@ -169,3 +169,4 @@ secrets: {}
 additionalSecretNames: {}
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}

--- a/charts/comet-api-v2/templates/deployment.yaml
+++ b/charts/comet-api-v2/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-api-v2/values.yaml
+++ b/charts/comet-api-v2/values.yaml
@@ -171,3 +171,4 @@ secrets: {}
 additionalSecretNames: {}
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}

--- a/charts/comet-api-v3/templates/deployment.yaml
+++ b/charts/comet-api-v3/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-api-v3/values.yaml
+++ b/charts/comet-api-v3/values.yaml
@@ -171,3 +171,4 @@ secrets: {}
 additionalSecretNames: {}
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}

--- a/charts/comet-ingress-v1/templates/ingress.yaml
+++ b/charts/comet-ingress-v1/templates/ingress.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- range $key, $val := $.Values.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+    {{- if $.Values.zeroScaling.enabled }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ include "comet-ingress.fullname" $ }}-zero-scaling@kubernetescrd
+    {{- end }}
 spec:
   ingressClassName: nginx
   rules:

--- a/charts/comet-ingress-v1/templates/zero-scaling-middleware.yaml
+++ b/charts/comet-ingress-v1/templates/zero-scaling-middleware.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.zeroScaling.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "comet-ingress.fullname" . }}-zero-scaling
+  labels:
+    {{- include "comet-ingress.labels" . | nindent 4 }}
+spec:
+  plugin:
+    sablier:
+      sablierUrl: {{ .Values.zeroScaling.sablierUrl | quote }}
+      group: {{ .Values.zeroScaling.group | default .Release.Namespace | quote }}
+      sessionDuration: {{ .Values.zeroScaling.sessionDuration | quote }}
+      failOpen: {{ .Values.zeroScaling.failOpen }}
+      {{- with .Values.zeroScaling.ignoreUserAgent }}
+      ignoreUserAgent:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      dynamic:
+        displayName: {{ .Values.zeroScaling.dynamic.displayName | default .Release.Name | quote }}
+{{- end }}

--- a/charts/comet-ingress-v1/values.yaml
+++ b/charts/comet-ingress-v1/values.yaml
@@ -5,6 +5,30 @@
 annotations:
   cert-manager.io/cluster-issuer: "letsencrypt"
   nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+
+# Scale-to-zero support via Sablier (https://sablierapp.dev): renders a
+# Traefik middleware that starts the deployments of the configured Sablier
+# group on demand and attaches it to all ingresses of this chart. Requires a
+# Sablier instance and the Sablier Traefik plugin in the cluster.
+zeroScaling:
+  enabled: false
+  # URL of the central Sablier instance
+  sablierUrl: "http://sablier-networking.networking:10000"
+  # Sablier group to start; defaults to the release namespace, so all workloads
+  # in the namespace labeled with sablier.group=<namespace> wake up together
+  group: ""
+  # How long the group stays up after the last request
+  sessionDuration: "30m"
+  # Pass requests through to the backend when Sablier is unreachable instead
+  # of failing the request
+  failOpen: true
+  # Requests whose User-Agent matches any of these Go regexps are passed
+  # through without starting or extending a session (e.g. uptime checks)
+  ignoreUserAgent: []
+  dynamic:
+    # Title of the waiting page shown while the group starts;
+    # defaults to the release name
+    displayName: ""
 # Example Ingress configuration:
 # ingresses:
 #   - hostname: admin.comet-dxp.com

--- a/charts/comet-site-preview-v1/templates/deployment.yaml
+++ b/charts/comet-site-preview-v1/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/comet-site-preview-v1/values.yaml
+++ b/charts/comet-site-preview-v1/values.yaml
@@ -6,6 +6,7 @@ secrets: {}
 additionalSecretNames: []
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}
 
 replicaCount: 2
 

--- a/charts/comet-site-preview-v2/templates/deployment.yaml
+++ b/charts/comet-site-preview-v2/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/comet-site-preview-v2/values.yaml
+++ b/charts/comet-site-preview-v2/values.yaml
@@ -6,6 +6,7 @@ secrets: {}
 additionalSecretNames: []
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}
 
 replicaCount: 2
 

--- a/charts/comet-site-v1/templates/deployment.yaml
+++ b/charts/comet-site-v1/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-site-v1/templates/prelogin-deployment.yml
+++ b/charts/comet-site-v1/templates/prelogin-deployment.yml
@@ -8,6 +8,12 @@ metadata:
 {{- range $key, $val := .Values.prelogin.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.prelogin.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
   replicas: {{ .Values.prelogin.replicaCount }}
   selector:

--- a/charts/comet-site-v1/values.yaml
+++ b/charts/comet-site-v1/values.yaml
@@ -10,6 +10,7 @@ secrets: {}
 additionalSecretNames: []
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}
 
 replicaCount: 1
 
@@ -97,6 +98,7 @@ prelogin:
   autoMountServiceAccountToken: false
   additionalPodLabels: {}
   additionalDeploymentLabels: {}
+  additionalDeploymentAnnotations: {}
   secrets: {}
 
   image:

--- a/charts/comet-site-v2/templates/deployment.yaml
+++ b/charts/comet-site-v2/templates/deployment.yaml
@@ -7,6 +7,12 @@ metadata:
 {{- range $key, $val := .Values.additionalDeploymentLabels }}
     {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- with .Values.additionalDeploymentAnnotations }}
+  annotations:
+{{- range $key, $val := . }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/comet-site-v2/values.yaml
+++ b/charts/comet-site-v2/values.yaml
@@ -10,6 +10,7 @@ secrets: {}
 additionalSecretNames: []
 additionalPodLabels: {}
 additionalDeploymentLabels: {}
+additionalDeploymentAnnotations: {}
 
 replicaCount: 1
 


### PR DESCRIPTION
Adds scale-to-zero support via [Sablier](https://sablierapp.dev/) in two parts:

## `additionalDeploymentAnnotations` (all workload charts)

New value to set custom annotations on the Deployment metadata — analogous to the existing `additionalDeploymentLabels`. Needed for Sablier configuration values that are not valid as labels, e.g. `sablier.running-hours: "09:00-17:00"` (colons) or `sablier.running-days: "Mon,Tue,Wed,Thu,Fri"` (commas).

Applies to comet-admin-v1/v2, comet-api-v1/v2/v3, comet-site-v1 (incl. prelogin deployment via `prelogin.additionalDeploymentAnnotations`), comet-site-v2 and comet-site-preview-v1/v2.

## `zeroScaling` values block (comet-ingress-v1)

When `zeroScaling.enabled` is set, the chart renders a Traefik middleware using the Sablier plugin (dynamic strategy with waiting page) and attaches it to all ingresses via the `traefik.ingress.kubernetes.io/router.middlewares` annotation, so incoming requests start the deployments of the configured Sablier group on demand.

```yaml
zeroScaling:
  enabled: true
  sablierUrl: "http://sablier-networking.networking:10000"
  group: ""              # defaults to the release namespace
  sessionDuration: "30m"
  failOpen: true         # pass requests through if Sablier is unreachable
  ignoreUserAgent: []    # e.g. uptime checks that must not wake the group
  dynamic:
    displayName: ""      # waiting page title, defaults to the release name
```

Requires a Sablier instance and the [Sablier Traefik plugin](https://github.com/sablierapp/sablier-traefik-plugin) in the cluster. Workloads opt in via `sablier.enable=true` / `sablier.group=<namespace>` labels (settable through `additionalDeploymentLabels` since the last release).

## Verification

- `helm lint` passes for all changed charts
- `helm template` checked: annotations render on the Deployment metadata (incl. prelogin), middleware + ingress annotation render only when `zeroScaling.enabled` is set, group defaults to the release namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)