### PR TITLE
fix: Append zero-scaling middleware to existing router.middlewares an…

### DIFF
--- a/.changeset/thin-donkeys-brake.md
+++ b/.changeset/thin-donkeys-brake.md
@@ -1,0 +1,5 @@
+---
+"comet-ingress-v1": patch
+---
+
+Append the zero-scaling middleware to an existing `traefik.ingress.kubernetes.io/router.middlewares` annotation instead of emitting a duplicate key. Previously, when `zeroScaling.enabled` was set and the `annotations` value already contained `traefik.ingress.kubernetes.io/router.middlewares` (e.g. for a project-specific IP allowlist middleware), the rendered ingress contained the key twice and the zero-scaling entry silently replaced the configured one. Now both middlewares are combined into a single comma-separated list, with the zero-scaling middleware appended last.

--- a/charts/comet-ingress-v1/templates/ingress.yaml
+++ b/charts/comet-ingress-v1/templates/ingress.yaml
@@ -8,12 +8,14 @@ metadata:
   labels:
     {{- include "comet-ingress.labels" $ | nindent 4 }}
   annotations:
-    {{- range $key, $val := $.Values.annotations }}
-    {{ $key }}: {{ $val | quote }}
-    {{- end }}
+    {{- $annotations := deepCopy ($.Values.annotations | default dict) }}
     {{- if $.Values.zeroScaling.enabled }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ include "comet-ingress.fullname" $ }}-zero-scaling@kubernetescrd
+    {{- /* append to an existing router.middlewares annotation instead of emitting a duplicate key */}}
+    {{- $middlewaresKey := "traefik.ingress.kubernetes.io/router.middlewares" }}
+    {{- $zeroScalingMiddleware := printf "%s-%s-zero-scaling@kubernetescrd" $.Release.Namespace (include "comet-ingress.fullname" $) }}
+    {{- $_ := set $annotations $middlewaresKey (compact (list (get $annotations $middlewaresKey) $zeroScalingMiddleware) | join ",") }}
     {{- end }}
+    {{- toYaml $annotations | nindent 4 }}
 spec:
   ingressClassName: nginx
   rules:

--- a/charts/comet-ingress-v1/values.yaml
+++ b/charts/comet-ingress-v1/values.yaml
@@ -8,7 +8,9 @@ annotations:
 
 # Scale-to-zero support via Sablier (https://sablierapp.dev): renders a
 # Traefik middleware that starts the deployments of the configured Sablier
-# group on demand and attaches it to all ingresses of this chart. Requires a
+# group on demand and attaches it to all ingresses of this chart. If the
+# annotations above already contain traefik.ingress.kubernetes.io/router.middlewares,
+# the zero-scaling middleware is appended to the existing list. Requires a
 # Sablier instance and the Sablier Traefik plugin in the cluster.
 zeroScaling:
   enabled: false


### PR DESCRIPTION
…notation

When zeroScaling.enabled is set and the annotations value already contains traefik.ingress.kubernetes.io/router.middlewares, the rendered ingress contained the key twice and the zero-scaling entry silently replaced the configured one. Combine both into a single comma-separated list instead.