### PR TITLE
Add extraVolumeMounts/extraVolumes support to comet-api-v3 CronJobs

### DIFF
--- a/.changeset/comet-api-v3-cronjob-extra-volumes.md
+++ b/.changeset/comet-api-v3-cronjob-extra-volumes.md
@@ -1,0 +1,5 @@
+---
+"comet-api-v3": minor
+---
+
+Add `extraVolumeMounts`/`extraVolumes` support to `cronJobs.<name>` entries, so a CronJob's container can mount additional volumes (e.g. a PersistentVolumeClaim for a persistent cache) — previously the only mountable volume was the service-account token.

--- a/charts/comet-api-v3/templates/cron-jobs.yaml
+++ b/charts/comet-api-v3/templates/cron-jobs.yaml
@@ -91,6 +91,9 @@ spec:
                   name: service-account
                   readOnly: true
       {{- end }}
+      {{- with $job.extraVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+      {{- end }}
               resources:
                 {{- $job.resources | default .Values.resources | toYaml | nindent 16 }}
           volumes:
@@ -98,6 +101,9 @@ spec:
             - name: "service-account"
               secret:
                 secretName: {{ include "comet-api.fullname" . }}-service-account-token
+      {{- end }}
+      {{- with $job.extraVolumes }}
+            {{- toYaml . | nindent 12 }}
       {{- end }}
 ---
     {{- end }}

--- a/charts/comet-api-v3/values.yaml
+++ b/charts/comet-api-v3/values.yaml
@@ -119,6 +119,8 @@ cronJobs:
     instanceNameOverride: ""
     additionalAnnotations: {}
     additionalPodLabels: {}
+    extraVolumeMounts: []
+    extraVolumes: []
     activeDeadlineSeconds: 600
     resources:
       limits:
@@ -136,6 +138,8 @@ cronJobs:
     additionalAnnotations: {}
     additionalLabels: {}
     additionalPodLabels: {}
+    extraVolumeMounts: []
+    extraVolumes: []
     resources:
       limits:
         cpu: 100m
@@ -153,6 +157,8 @@ cronJobs:
     additionalAnnotations: {}
     additionalLabels: {}
     additionalPodLabels: {}
+    extraVolumeMounts: []
+    extraVolumes: []
     resources:
       limits:
         cpu: 2


### PR DESCRIPTION
**Problem:**

A cronjob run's multiple times, e.g. restart after failure, and the bottleneck is downloading external files. Without persistent volumes cached data is lost on pod-restart. For downloading files this means always putting stress on the providing-server resulting in more frequent errors and re-doing time consuming requests.

The CronJob template only ever mounted the service-account-token volume, with no way to attach a custom volume (e.g. a PersistentVolumeClaim for a persistent cache) to a specific job's container.

**Solution:**

This PR adds optional extraVolumeMounts/extraVolumes per cronJobs.<name> entry, following the same per-job customization pattern as additionalPodLabels/additionalAnnotations.