### PR TITLE
Make CronJob schedule optional when suspend: true

### DIFF
--- a/.changeset/comet-api-v3-optional-cronjob-schedule.md
+++ b/.changeset/comet-api-v3-optional-cronjob-schedule.md
@@ -1,0 +1,5 @@
+---
+"comet-api-v3": minor
+---
+
+Make `cronJobs.<name>.schedule` optional when `suspend: true` — the template now defaults it to a harmless placeholder in that case, instead of requiring every manual-trigger-only job to set a dummy cron expression by hand. `schedule` is still required (and now fails at `helm template`/`helm lint` time with a clear error, instead of only at `kubectl apply` time) whenever `suspend` is not `true`, since the Kubernetes CronJob API itself always requires a non-empty schedule regardless of `suspend`.

--- a/charts/comet-api-v3/templates/cron-jobs.yaml
+++ b/charts/comet-api-v3/templates/cron-jobs.yaml
@@ -16,7 +16,13 @@ metadata:
       {{- tpl ($job.additionalLabels | toYaml) . | nindent 4 }}
       {{- end }}
 spec:
+  {{- if $job.schedule }}
   schedule: {{ $job.schedule | quote }}
+  {{- else if $job.suspend }}
+  schedule: "0 0 1 1 *" # no schedule given while suspended — placeholder, never evaluated (Kubernetes' CronJob API always requires some valid cron expression here, regardless of suspend)
+  {{- else }}
+  {{ fail (printf "cronJobs.%s.schedule is required unless suspend: true — Kubernetes' CronJob API always requires a schedule; either set one or set suspend: true for a manual-trigger-only job" $name) }}
+  {{- end }}
   suspend: {{ $job.suspend | default false }}
   timeZone: {{ $job.timeZone | default "Europe/Vienna" }}
   successfulJobsHistoryLimit: {{ $job.successfulJobsHistoryLimit | default 2 }}


### PR DESCRIPTION
Every manual-trigger-only job previously had to set a dummy "never runs" cron expression by hand (e.g. the 30th-of-February trick) just to satisfy Kubernetes' CronJob API, which always requires a non-empty schedule regardless of suspend. The template now fills in a harmless placeholder automatically when suspend: true and no schedule is given.

schedule remains required whenever suspend is not true — omitting it there now fails fast at helm template/lint time with a clear error, instead of only surfacing as a cryptic "spec.schedule: Required value" from the API server at kubectl apply time.