### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # comet-charts
 
+> **Deprecated.** These charts are continued under the Dextinity name, one repository per chart. Each successor starts at version `1.0.0` and is published to `oci://ghcr.io/vivid-planet/charts` instead of a `helm repo` URL.
+>
+> | Chart here              | Continued in                                                                                 |
+> | ----------------------- | -------------------------------------------------------------------------------------------- |
+> | `comet-admin-v2`        | [dextinity-admin-chart](https://github.com/vivid-planet/dextinity-admin-chart)               |
+> | `comet-api-v3`          | [dextinity-api-chart](https://github.com/vivid-planet/dextinity-api-chart)                   |
+> | `comet-ingress-v1`      | [dextinity-ingress-chart](https://github.com/vivid-planet/dextinity-ingress-chart)           |
+> | `comet-site-v2`         | [dextinity-site-chart](https://github.com/vivid-planet/dextinity-site-chart)                 |
+> | `comet-site-preview-v2` | [dextinity-site-preview-chart](https://github.com/vivid-planet/dextinity-site-preview-chart) |
+>
+> The older major versions in this repository have no successor. Move them to the current major here before switching to the Dextinity chart.
+
 Helm charts for Comet DXP.
 
 ## Versioning


### PR DESCRIPTION
This repo is deprecated. The new charts are in their own repos under the name dextinity